### PR TITLE
allow operator to override compression

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -107,6 +107,12 @@ public class RobotContainer {
   // Used during disabled/pre-match to verify the robot is placed correctly.
   public final Field2d autoPreviewField = new Field2d();
 
+  // ── Compress Cancellation Tracking ──────────────────────────────────────────
+  // When the driver overrides the automatic compress (by pressing intake in/out/compress),
+  // this flag is set to true so the auto-compress won't reschedule until the shoot button
+  // is released. Reset to false when the shoot button is released.
+  private boolean compressCancelled = false;
+
   // Stores the starting pose of the currently selected auto.
   // Updated when the auto chooser selection changes.
   private Pose2d autoStartPose = new Pose2d();
@@ -567,32 +573,48 @@ public class RobotContainer {
         .onFalse(intakeRollerCommands.stopIntakeRoller(intakeRoller));
 
     // INTAKE PIVOT
-    // Retract on retract button — also cancels compression for this shoot press
+    // Retract on retract button — also cancels automatic compression for this shoot press
     Triggers.getInstance()
         .intakeInButton()
+        .onTrue(Commands.runOnce(() -> compressCancelled = true))
         .whileTrue(
             IntakePivotCommands.setPivotPosition(
                 intakePivot, HardwareConstants.CompConstants.Positions.pivotUpPos));
 
-    // Deploy on deploy button — also cancels compression for this shoot press
+    // Deploy on deploy button — also cancels automatic compression for this shoot press
     Triggers.getInstance()
         .intakeOutButton()
+        .onTrue(Commands.runOnce(() -> compressCancelled = true))
         .whileTrue(
             IntakePivotCommands.setPivotPosition(
                 intakePivot, HardwareConstants.CompConstants.Positions.pivotDownPos));
 
-    // Compress on shoot button when:
+    // Manual compress button — cancels auto-compress and runs compress with no initial wait
+    Triggers.getInstance()
+        .intakeCompressButton()
+        .onTrue(Commands.runOnce(() -> compressCancelled = true))
+        .whileTrue(IntakePivotCommands.compressPivot(intakePivot, true))
+        .onFalse(
+            IntakePivotCommands.setPivotPosition(
+                intakePivot, HardwareConstants.CompConstants.Positions.pivotDownPos));
+
+    // Reset the cancellation flag when the shoot button is released so auto-compress
+    // can activate on the next shoot press
+    Triggers.getInstance().shootButton().onFalse(Commands.runOnce(() -> compressCancelled = false));
+
+    // Automatic compress on shoot button when:
     //   - neither intake deploy nor retract button is currently pressed
     //   - compression has not been cancelled by a prior intake override this shoot press
     //   - we're not in our alliance zone with the hub inactive
-    // Also starts on the dedicated compress button.
-    (Triggers.getInstance()
-            .shootButton()
-            .and(() -> !Triggers.getInstance().intakeOutButton().getAsBoolean())
-            .and(() -> !Triggers.getInstance().intakeInButton().getAsBoolean())
-            .and(() -> !(Triggers.getInstance().isShootSafeZone.getAsBoolean() && 
-                !Triggers.getInstance().isShootSafeTimeSure.getAsBoolean())))
-        .or(Triggers.getInstance().intakeCompressButton())
+    Triggers.getInstance()
+        .shootButton()
+        .and(() -> !Triggers.getInstance().intakeOutButton().getAsBoolean())
+        .and(() -> !Triggers.getInstance().intakeInButton().getAsBoolean())
+        .and(() -> !compressCancelled)
+        .and(
+            () ->
+                !(Triggers.getInstance().isShootSafeZone.getAsBoolean()
+                    && !Triggers.getInstance().isShootSafeTimeSure.getAsBoolean()))
         .whileTrue(IntakePivotCommands.compressPivot(intakePivot))
         .onFalse(
             IntakePivotCommands.setPivotPosition(
@@ -808,29 +830,41 @@ public class RobotContainer {
         .onFalse(intakeRollerCommands.stopIntakeRoller(intakeRoller));
 
     // INTAKE PIVOT
-    // Retract on retract button — also cancels compression for this shoot press
+    // Retract on retract button — also cancels automatic compression for this shoot press
     Triggers.getInstance()
         .simIntakeInButton()
+        .onTrue(Commands.runOnce(() -> compressCancelled = true))
         .whileTrue(
             IntakePivotCommands.setPivotPosition(
                 intakePivot, HardwareConstants.CompConstants.Positions.pivotUpPos));
 
-    // Deploy on deploy button — also cancels compression for this shoot press
+    // Deploy on deploy button — also cancels automatic compression for this shoot press
     Triggers.getInstance()
         .simIntakeOutButton()
+        .onTrue(Commands.runOnce(() -> compressCancelled = true))
         .whileTrue(
             IntakePivotCommands.setPivotPosition(
                 intakePivot, HardwareConstants.CompConstants.Positions.pivotDownPos));
 
-    // Compress on shoot button when:
+    // Manual compress button — cancels auto-compress and runs compress with no initial wait
+    Triggers.getInstance()
+        .simIntakeCompressButton()
+        .onTrue(Commands.runOnce(() -> compressCancelled = true))
+        .whileTrue(IntakePivotCommands.compressPivot(intakePivot, true));
+
+    // Reset the cancellation flag when the shoot button is released
+    Triggers.getInstance()
+        .simShootButton()
+        .onFalse(Commands.runOnce(() -> compressCancelled = false));
+
+    // Automatic compress on shoot button when:
     //   - neither intake deploy nor retract button is currently pressed
     //   - compression has not been cancelled by a prior intake override this shoot press
-    // Also starts on the dedicated compress button.
-    (Triggers.getInstance()
-            .simShootButton()
-            .and(() -> !Triggers.getInstance().simIntakeOutButton().getAsBoolean())
-            .and(() -> !Triggers.getInstance().simIntakeInButton().getAsBoolean()))
-        .or(Triggers.getInstance().simIntakeCompressButton())
+    Triggers.getInstance()
+        .simShootButton()
+        .and(() -> !Triggers.getInstance().simIntakeOutButton().getAsBoolean())
+        .and(() -> !Triggers.getInstance().simIntakeInButton().getAsBoolean())
+        .and(() -> !compressCancelled)
         .whileTrue(IntakePivotCommands.compressPivot(intakePivot));
 
     // HOOD

--- a/src/main/java/frc/robot/commands/IntakePivotCommands.java
+++ b/src/main/java/frc/robot/commands/IntakePivotCommands.java
@@ -72,26 +72,25 @@ public class IntakePivotCommands {
         .withName("IntakePivotJostle");
   }
 
-  public static Command compressPivot(IntakePivot intakePivot) {
-    // return Commands.sequence(
-    //         Commands.deadline(
-    //             new WaitCommand(1), IntakePivotCommands.setPivotVoltage(intakePivot,
-    // Volts.of(3))),
-    //         new WaitCommand(0.3),
-    //         IntakePivotCommands.setPivotPosition(
-    //             intakePivot, HardwareConstants.CompConstants.Positions.pivotDownPos))
-    //     .repeatedly()
-    //     .finallyDo(
-    //         (interrupted) -> {
-    //           // Only reset to down position if the command ended naturally (not interrupted).
-    //           // If interrupted by the driver pressing intake in/out, we don't want to
-    //           // override the position they just commanded.
-    //           if (!interrupted) {
-    //             intakePivot.setPivotPosition(
-    //                 HardwareConstants.CompConstants.Positions.pivotDownPos);
-    //           }
-    //         })
+  /**
+   * Compress the pivot to jostle game pieces into position.
+   *
+   * @param intakePivot The intake pivot subsystem
+   * @param skipFirstWait If true, skip the initial wait and start compressing immediately (used for
+   *     manual compress button). If false, wait before starting (used for automatic compress during
+   *     shooting).
+   */
+  public static Command compressPivot(IntakePivot intakePivot, boolean skipFirstWait) {
     Logger.recordOutput("RobotState/IntakePivot", "JostleCalled");
+    if (skipFirstWait) {
+      return Commands.sequence(
+              setPivotPosition(
+                  intakePivot, HardwareConstants.CompConstants.Positions.pivotJostleMiddlePos),
+              new WaitCommand(HardwareConstants.CompConstants.Waits.waitBetweenCompressSeconds),
+              setPivotPosition(
+                  intakePivot, HardwareConstants.CompConstants.Positions.pivotJostleUpPos))
+          .withName("IntakePivotCompress");
+    }
     return Commands.sequence(
             new WaitCommand(HardwareConstants.CompConstants.Waits.waitToCompressSeconds),
             setPivotPosition(
@@ -100,6 +99,11 @@ public class IntakePivotCommands {
             setPivotPosition(
                 intakePivot, HardwareConstants.CompConstants.Positions.pivotJostleUpPos))
         .withName("IntakePivotCompress");
+  }
+
+  /** Overload that defaults to NOT skipping the first wait (backward-compatible). */
+  public static Command compressPivot(IntakePivot intakePivot) {
+    return compressPivot(intakePivot, false);
   }
 
   public static Command autoPivotCompress(IntakePivot intakePivot) {

--- a/src/main/java/frc/robot/commands/IntakePivotCommands.java
+++ b/src/main/java/frc/robot/commands/IntakePivotCommands.java
@@ -9,8 +9,10 @@ import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
+import frc.lib.ContinuousConditionalCommand;
 import frc.robot.HardwareConstants;
 import frc.robot.subsystems.intakePivot.IntakePivot;
+import java.util.function.BooleanSupplier;
 import org.littletonrobotics.junction.Logger;
 
 /**
@@ -75,30 +77,52 @@ public class IntakePivotCommands {
   /**
    * Compress the pivot to jostle game pieces into position.
    *
+   * <p>Uses a {@link BooleanSupplier} evaluated at schedule time (not creation time) so the
+   * correct branch is always chosen when the command actually runs.
+   * {@link ContinuousConditionalCommand} also re-evaluates the condition while running, so if the
+   * condition changes mid-execution the command will switch branches automatically.
+   *
    * @param intakePivot The intake pivot subsystem
-   * @param skipFirstWait If true, skip the initial wait and start compressing immediately (used for
-   *     manual compress button). If false, wait before starting (used for automatic compress during
-   *     shooting).
+   * @param skipFirstWait Supplier evaluated continuously: {@code true} = skip initial wait and
+   *     start compressing immediately (manual compress); {@code false} = wait before starting
+   *     (automatic compress during shooting).
+   */
+  public static Command compressPivot(IntakePivot intakePivot, BooleanSupplier skipFirstWait) {
+    Logger.recordOutput("RobotState/IntakePivot", "JostleCalled");
+
+    // Branch A: skip the initial wait — used for manual compress button presses
+    Command skipWaitBranch =
+        Commands.sequence(
+                setPivotPosition(
+                    intakePivot, HardwareConstants.CompConstants.Positions.pivotJostleMiddlePos),
+                new WaitCommand(HardwareConstants.CompConstants.Waits.waitBetweenCompressSeconds),
+                setPivotPosition(
+                    intakePivot, HardwareConstants.CompConstants.Positions.pivotJostleUpPos))
+            .withName("IntakePivotCompress_SkipWait");
+
+    // Branch B: include the initial wait — used for automatic compress during shooting
+    Command withWaitBranch =
+        Commands.sequence(
+                new WaitCommand(HardwareConstants.CompConstants.Waits.waitToCompressSeconds),
+                setPivotPosition(
+                    intakePivot, HardwareConstants.CompConstants.Positions.pivotJostleMiddlePos),
+                new WaitCommand(HardwareConstants.CompConstants.Waits.waitBetweenCompressSeconds),
+                setPivotPosition(
+                    intakePivot, HardwareConstants.CompConstants.Positions.pivotJostleUpPos))
+            .withName("IntakePivotCompress_WithWait");
+
+    // ContinuousConditionalCommand evaluates skipFirstWait each loop, so the right
+    // branch is always active — even if the condition changes while the command is running.
+    return new ContinuousConditionalCommand(skipWaitBranch, withWaitBranch, skipFirstWait)
+        .withName("IntakePivotCompress");
+  }
+
+  /**
+   * Overload that accepts a plain {@code boolean} for call sites that always pass a literal.
+   * Wraps the value in a supplier so it still uses the {@link ContinuousConditionalCommand} path.
    */
   public static Command compressPivot(IntakePivot intakePivot, boolean skipFirstWait) {
-    Logger.recordOutput("RobotState/IntakePivot", "JostleCalled");
-    if (skipFirstWait) {
-      return Commands.sequence(
-              setPivotPosition(
-                  intakePivot, HardwareConstants.CompConstants.Positions.pivotJostleMiddlePos),
-              new WaitCommand(HardwareConstants.CompConstants.Waits.waitBetweenCompressSeconds),
-              setPivotPosition(
-                  intakePivot, HardwareConstants.CompConstants.Positions.pivotJostleUpPos))
-          .withName("IntakePivotCompress");
-    }
-    return Commands.sequence(
-            new WaitCommand(HardwareConstants.CompConstants.Waits.waitToCompressSeconds),
-            setPivotPosition(
-                intakePivot, HardwareConstants.CompConstants.Positions.pivotJostleMiddlePos),
-            new WaitCommand(HardwareConstants.CompConstants.Waits.waitBetweenCompressSeconds),
-            setPivotPosition(
-                intakePivot, HardwareConstants.CompConstants.Positions.pivotJostleUpPos))
-        .withName("IntakePivotCompress");
+    return compressPivot(intakePivot, () -> skipFirstWait);
   }
 
   /** Overload that defaults to NOT skipping the first wait (backward-compatible). */


### PR DESCRIPTION
Allows Lucas to cancel the compression by hitting the intake up, down or compress button. Also, makes it so when you hit the manual compress button it will start compressing right away instead of having the first wait. This means we can tune the compression for a full hopper. And, on small hoppers we can hit the manual compress button or intake up button. Or, if he sees it getting jammed then he can press the down button.



Prompt used: 

#file:default.instructions.md 
can you help me with some logic. I would like to make it so that when the driver presses the shoot button the intake automatically runs the compress sequence. this already hapoens correctly. if the driver is holding the shoot button and the press the intake up or down or compress buttons, the automatic compress sequence should be interrupted and do what the user commanded. the automatic compress should not be rescheduled until the driver has released the shoot button. i previously had this implemented by using a boolean in #file:RobotContainer.java to track if the compress sequence was cancelled or not. 

can you help reimplekent this. 

note that, as part of this update, I would like to add a boolean to my compress command in #sym:IntakePivotCommands to skip the first wait in the command sequence. the manually compress button should use this flag to skip the first wait so the pivot starts compressing right away. all other places in my code should use the sequence as it currently is