### PR TITLE
Fix defense-shot scheduling/bindings and shoot-on-the-move X-lock (issue #83)

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -18,7 +18,6 @@ import com.pathplanner.lib.events.EventTrigger;
 import com.pathplanner.lib.path.PathPlannerPath;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
@@ -463,9 +462,9 @@ public class RobotContainer {
                 DriveCommands.alignForDefenseShot(drive),
                 DriveCommands.alignOrXForShoot(
                     drive,
-                    () -> Triggers.getInstance().simXSupplier(),
-                    () -> Triggers.getInstance().simYSupplier(),
-                    () -> new Rotation2d(Triggers.getInstance().simRotationSupplier()))));
+                    () -> -thrustmaster.getY() * .5,
+                    () -> -thrustmaster.getX() * .5,
+                    () -> RobotState.getInstance().getAngleToAllianceHub())));
 
     // Align for pass if shoot button is pressed but we're not in our alliance zone, or if pass
     // button is pressed

--- a/src/main/java/frc/robot/commands/DriveCommands.java
+++ b/src/main/java/frc/robot/commands/DriveCommands.java
@@ -187,8 +187,8 @@ public class DriveCommands {
         joystickDriveAtAngle(drive, xSupplier, ySupplier, rotationSupplier),
         () ->
             Triggers.getInstance().isAlignedForCurrentShot.getAsBoolean()
-                && xSupplier.getAsDouble() < 0.1
-                && ySupplier.getAsDouble() < 0.1);
+                && Math.abs(xSupplier.getAsDouble()) < DEADBAND
+                && Math.abs(ySupplier.getAsDouble()) < DEADBAND);
   }
 
   public static Command alignForDefenseShot(Drive drive) {

--- a/src/main/java/frc/robot/commands/DriveCommands.java
+++ b/src/main/java/frc/robot/commands/DriveCommands.java
@@ -35,6 +35,7 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 import org.littletonrobotics.junction.Logger;
@@ -191,35 +192,41 @@ public class DriveCommands {
                 && Math.abs(ySupplier.getAsDouble()) < DEADBAND);
   }
 
+  // Pathfinds to the nearest hardstop spot once, then follows that path until the target is
+  // reached or the command is cancelled (driver releases the button). The target pose is computed
+  // once at schedule time via defer — scheduling a new pathfinder every loop interrupts itself
+  // and never makes progress.
   public static Command alignForDefenseShot(Drive drive) {
-    return Commands.run(
-        () -> {
-          drive.aligningDefensively = true;
+    return Commands.defer(
+            () -> {
+              double targetx = AllianceFlipUtil.applyX(3.5);
+              double targety;
+              if (AllianceFlipUtil.applyY(RobotState.getInstance().getEstimatedPose().getY())
+                  >= 4.0) {
+                targety = AllianceFlipUtil.applyY(6.5);
+              } else {
+                targety = AllianceFlipUtil.applyY(1.5);
+              }
 
-          double targetx = AllianceFlipUtil.applyX(3.5);
-          double targety;
-          if (AllianceFlipUtil.applyY(RobotState.getInstance().getEstimatedPose().getY()) >= 4.0) {
-            targety = AllianceFlipUtil.applyY(6.5);
-          } else {
-            targety = AllianceFlipUtil.applyY(1.5);
-          }
+              // Similar mechanism to getAngleToAllianceHub(), only using target pose instead of
+              // current pose
+              // Get alliance hub target (2D position on the field)
+              Translation3d hubTarget3d = RobotState.getInstance().getAllianceHubTarget();
+              Translation2d hubTarget2d = hubTarget3d.toTranslation2d();
+              // Calculate the vector from target pose to hub
+              Translation2d robotToHub = hubTarget2d.minus(new Translation2d(targetx, targety));
+              // Calculate angle
+              Rotation2d targetRotation =
+                  new Rotation2d(robotToHub.getX(), robotToHub.getY()).plus(Rotation2d.kPi);
 
-          // Similar mechanism to getAngleToAllianceHub(), only using target pose instead of current
-          // pose
-          // Get alliance hub target (2D position on the field)
-          Translation3d hubTarget3d = RobotState.getInstance().getAllianceHubTarget();
-          Translation2d hubTarget2d = hubTarget3d.toTranslation2d();
-          // Calculate the vector from target pose to hub
-          Translation2d robotToHub = hubTarget2d.minus(new Translation2d(targetx, targety));
-          // Calculate angle
-          Rotation2d targetRotation =
-              new Rotation2d(robotToHub.getX(), robotToHub.getY()).plus(Rotation2d.kPi);
+              Pose2d targetPose = new Pose2d(targetx, targety, targetRotation);
 
-          Pose2d targetPose = new Pose2d(targetx, targety, targetRotation);
-
-          drive.alignForDefenseShot(targetPose);
-        },
-        drive);
+              return drive.alignForDefenseShot(targetPose);
+            },
+            Set.of(drive))
+        .beforeStarting(() -> drive.aligningDefensively = true)
+        .finallyDo(() -> drive.aligningDefensively = false)
+        .withName("Drive_AlignForDefenseShot");
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -279,11 +279,14 @@ public class Drive extends SubsystemBase {
     stop();
   }
 
-  public void alignForDefenseShot(Pose2d targetPose) {
-    Command followCommand =
-        AutoBuilder.pathfindToPose(targetPose, PathConstraints.unlimitedConstraints(12));
+  /**
+   * Returns a pathfinding command to the given pose. The caller schedules it (e.g. via a whileTrue
+   * binding) — returning instead of scheduling here avoids re-scheduling a new pathfinder every
+   * loop, which interrupts itself and never makes progress.
+   */
+  public Command alignForDefenseShot(Pose2d targetPose) {
     Logger.recordOutput("RobotState/targetPose", targetPose);
-    followCommand.schedule();
+    return AutoBuilder.pathfindToPose(targetPose, PathConstraints.unlimitedConstraints(12));
   }
 
   /** Returns a command to run a quasistatic test in the specified direction. */


### PR DESCRIPTION
Addresses the priority findings from the post-Worlds code review in #83 (W1 and W3). The vision fix was reviewed as correct and is untouched.

## W1 — Shoot-on-the-move X-lock ignored negative joystick input
`DriveCommands.alignOrXForShoot` compared raw supplier values against `0.1`, so any negative deflection (stick pulled back or left) read as "no input" and the robot X-locked while the driver was actively driving. Now uses `Math.abs(...) < DEADBAND` (same 0.1 value, via the existing named constant).

## W3 — Defense-shot align thrashed the scheduler and had an unreachable phase
- `Drive.alignForDefenseShot` used to build **and schedule** a new `pathfindToPose` command from inside a `Commands.run` loop — a fresh pathfinder every 20 ms, each one requiring `drive` and interrupting the last, so it never made progress (matches the "not aligning correctly" commit notes). It now **returns** the pathfind command, and the `DriveCommands.alignForDefenseShot` factory wraps it in `Commands.defer`: the target pose is computed once at schedule time and the robot follows that single path until it arrives or the driver releases the button (`whileTrue` cancels it).
- Because the pathfind command now finishes on arrival, phase 2 of the real binding's `Commands.sequence(alignForDefenseShot, alignOrXForShoot)` is reachable instead of dead code.
- The real-robot binding was passing **sim keyboard suppliers** into `alignOrXForShoot`; it now uses the thrustmaster suppliers and `getAngleToAllianceHub()`, matching the normal shoot-align binding.
- The `aligningDefensively` flag is now set via `beforeStarting`/`finallyDo` instead of every loop (no functional consumers today — only the unused `RobotContainer.aligningDefensively()` accessor).

## Behavioral consequences
- The robot will no longer X-lock mid-motion during shoot-on-the-move when the driver holds a negative stick direction.
- Holding the shoot button near the alliance trench now actually pathfinds to the hardstop spot, and on arrival hands off to align-or-X with real driver input. The defense-shot target pose is latched at button press — if the robot starts on one half of the field and crosses `y = 4.0 m` mid-path, it keeps the originally chosen spot (previously the target flapped every loop, though the pathfinder never ran long enough for it to matter).

## Not addressed here (needs a tuning session / team decision, per #83)
- **C1** — PathPlanner holonomic PID at 50.0 (was 5.0)
- **C2** — drive supply limit 70→40 A, `kSlipCurrent` 60→80 A
- **C3** — `Flywheel.shootDynamic()` unit bugs (sim-only wiring today)
- **W2** — `FlywheelCommands.shootOnTheMove` missing flywheel requirement and name

## Verification
- `./gradlew build` and `spotlessCheck` pass.
- Not yet run on a field — the defense-shot flow should be validated in sim (the sim binding exercises the same `alignForDefenseShot` factory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bgx9J3nPsbeSFoHsbrqXzS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved defense-shot alignment behavior so the robot now uses live driver controls and the current hub angle when aiming.
  * Made the defense-shot alignment command more reliable by creating and returning it at the right time instead of scheduling it repeatedly.
  * Added clearer command handling so defensive alignment state is set and cleared consistently during use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->