### PR TITLE
Tighten single-tag vision filtering to reject far/ambiguous PnP flips

### DIFF
--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -43,6 +43,12 @@ import org.littletonrobotics.junction.Logger;
  *       VisionConstants#maxPitchRollRadians} are rejected because a robot on flat carpet should
  *       never be significantly tilted; large tilt means the solve is wrong.
  * </ul>
+ *
+ * <p><b>Change log (2026-07-05):</b> Added single-tag distance filter — single-tag observations
+ * farther than {@link VisionConstants#maxSingleTagDistanceMeters} are rejected. Match-log analysis
+ * (State q30/e3, Worlds q2) showed every accepted pose that was 2.5–9.6 m wrong came from a
+ * single-tag solve at ≥ 3.8 m, some with near-zero ambiguity, so the ambiguity filter alone cannot
+ * catch them. Multi-tag observations keep the looser {@link VisionConstants#maxDistanceMeters}.
  */
 public class Vision extends SubsystemBase {
   private final VisionConsumer consumer;
@@ -149,6 +155,9 @@ public class Vision extends SubsystemBase {
           rejectionReason = "ZTooHigh"; // Must have realistic Z coordinate
         } else if (observation.averageTagDistance() > maxDistanceMeters) {
           rejectionReason = "TagsTooFar"; // Pose error grows with distance
+        } else if (observation.tagCount() == 1
+            && observation.averageTagDistance() > maxSingleTagDistanceMeters) {
+          rejectionReason = "SingleTagTooFar"; // Far single-tag solves can flip PnP solutions
         } else if (pitch > maxPitchRollRadians || roll > maxPitchRollRadians) {
           rejectionReason = "PitchRollTooLarge"; // Robot is on flat ground — solve is wrong
         } else if (observation.pose().getX() < 0.0

--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -82,9 +82,10 @@ public class VisionConstants {
   // ---- Filtering thresholds ----
 
   // Single-tag ambiguity above this is rejected (multi-tag is always trusted).
-  // Lowered from 0.2 → 0.1 to reduce false-positive single-tag solves
-  // that pick the wrong PnP solution.
-  public static double maxAmbiguity = 0.4; // 0.3
+  // Log analysis of State q30/e3 showed accepted single-tag solves with
+  // ambiguity 0.33–0.37 that were 3.3–3.4 m wrong (wrong PnP solution).
+  // 0.2 rejects those while keeping ~85% of single-tag observations.
+  public static double maxAmbiguity = 0.2; // was 0.4
 
   // Estimated pose Z (height) must be below this to be realistic
   public static double maxZError = 2;
@@ -95,6 +96,13 @@ public class VisionConstants {
   // Tags farther than this are unreliable — reject the observation entirely.
   // At long range, small pixel errors become large pose errors.
   public static double maxDistanceMeters = 6.0; // 4.0
+
+  // Stricter distance limit for SINGLE-tag observations only. Every
+  // catastrophic accepted pose in the State/Worlds logs (2.5–9.6 m wrong,
+  // including some with ambiguity ≈ 0) was a single-tag solve at ≥ 3.8 m.
+  // Multi-tag solves at 4–6 m were never catastrophically wrong, so they
+  // keep the looser maxDistanceMeters limit above.
+  public static double maxSingleTagDistanceMeters = 4.0;
 
   // If the robot is spinning faster than this (rad/s), vision is unreliable
   // because motion blur and timestamp misalignment degrade the estimate.


### PR DESCRIPTION
## Summary
Match-log analysis (State q30/e3, Worlds q2) showed every catastrophically wrong accepted vision pose (2.5–9.6 m off) came from a **single-tag solve at ≥ 3.8 m** — some with near-zero ambiguity, so the ambiguity filter alone cannot catch them. Two changes:

- **New `SingleTagTooFar` filter**: single-tag observations beyond `maxSingleTagDistanceMeters = 4.0 m` are rejected. Multi-tag observations keep the looser 6.0 m `maxDistanceMeters` limit — multi-tag solves at 4–6 m were never catastrophically wrong in the logs.
- **`maxAmbiguity` tightened 0.4 → 0.2**: log analysis showed accepted single-tag solves with ambiguity 0.33–0.37 that were 3.3–3.4 m wrong (flipped PnP solution). 0.2 rejects those while keeping ~85% of single-tag observations.

## Behavior / risk
- The robot relies more on odometry when only one distant tag is visible (e.g., far side of the neutral zone). Pose correction resumes as soon as a tag is within 4 m or a second tag appears.
- Failure mode if too strict: slower pose recovery after long vision-denied stretches. Rejections are logged per-camera with reason `SingleTagTooFar` for post-match review.

## Verification
- `./gradlew compileJava` passes on this branch (rebased onto main)
- Thresholds derived from AdvantageKit match logs; should be sanity-checked against live vision at next practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJeqB6PCwXQbZeRrBFiCBW