### PR TITLE
Restore AI development playbook and handbook docs

### DIFF
--- a/docs/ai-development-handbook.md
+++ b/docs/ai-development-handbook.md
@@ -1,0 +1,559 @@
+# AI Development Handbook
+
+**Guerin Robotics — How We Write Robot Code with AI**
+
+*The companion to the [AI-Assisted Robot Development Playbook](ai-development-playbook.md).
+The playbook is the **why**. This is the **how**. If you are a new programming
+student — freshman or senior — this is the document you learn from. It is a
+living document: we update it every season and every time something goes wrong
+that a rule here could have prevented.*
+
+> **A note on "Claude":** This handbook says "Claude" throughout because at the
+> time of writing, Claude is the best AI model available for this work. That
+> will change. Everything in this document — specs, context, review, testing,
+> the two tracks — applies to whatever AI tool we use. If the team switches
+> models someday, the process stays; only the name changes.
+
+---
+
+## Table of Contents
+
+1. [The one idea behind everything](#1-the-one-idea)
+2. [The AI knows the code, not the robot](#2-the-ai-knows-the-code-not-the-robot)
+3. [Two tracks: Full Loop and Fast Path](#3-two-tracks)
+4. [The Full Loop — building new code](#4-the-full-loop)
+5. [The Fast Path — tweaks, tuning, and bug fixes](#5-the-fast-path)
+6. [The season arc — spec, autos, tune](#6-the-season-arc)
+7. [Giving Claude context](#7-giving-claude-context)
+8. [Testing — Claude does it, you check it](#8-testing)
+9. [Skills and prompts — the toolkit](#9-skills-and-prompts)
+10. [The IO layer pattern](#10-the-io-layer-pattern)
+11. [Cheat sheet](#11-cheat-sheet)
+
+---
+
+## 1. The One Idea
+
+Software teams everywhere are converging on the same lifecycle for AI-assisted
+development — the industry version is called the
+[AI-SDLC](https://www.aisdlc.io/). Its core findings, translated to our team:
+
+- **AI helps at every stage** — writing specs, generating code, reviewing
+  diffs, generating tests, diagnosing failures, and analyzing logs after a
+  match. Not just the typing part.
+- **Guardrails come before speed.** We wrote our rules (`CLAUDE.md`,
+  `.claude/rules/`) *first*, so Claude can move fast *safely*. Never remove a
+  guardrail to go faster.
+- **AI writes, humans decide.** Claude generates the code and runs the tests.
+  A human reads every diff and approves every merge. The AI is the fast hands;
+  you are the judgment.
+- **Match the process to the risk.** A new subsystem and a one-line constant
+  change do not deserve the same ceremony. That's why we have two tracks (§3).
+
+One sentence to remember: **Claude writes and debugs the code; we describe the
+robot, review the changes, and own the result.**
+
+---
+
+## 2. The AI Knows the Code, Not the Robot
+
+This is the most important thing to understand before your first session.
+
+Claude Code is powerful for the software side of the robot, but **it does not
+automatically understand the physical robot. It only knows what we tell it.**
+It sees the code on your computer — it did not see what the robot just did on
+the field. It doesn't know the intake got bent in quarterfinals, that the new
+battery sags, or that the flywheel makes a grinding noise above 3000 RPM.
+
+Before asking Claude to write, debug, or improve robot code, give it clear
+context about the real machine:
+
+- **How the robot is built** — what each mechanism is, what it's for
+- **What motors and sensors are on it** — types, gear ratios, what's plugged in where
+- **What the robot is expected to do** — the behavior you want, with numbers
+- **What actually happened** — what you saw with your eyes, not just "it's broken"
+
+The better we explain the real robot, the better Claude writes code that
+actually works on the field. Every AI session that goes sideways goes sideways
+because the human assumed Claude knew something only the human knew.
+
+§7 covers exactly how to supply this context.
+
+---
+
+## 3. Two Tracks
+
+Not every change deserves the full process. The Full Loop exists because
+**building the initial solution is the hard part** — new subsystems, new
+sequences, new autos have to be designed, structured, and verified from
+scratch. Once the robot's code exists and works, most changes are small:
+add a button binding, adjust a PID gain, fix a bug, raise a current limit,
+tweak a timeout. Those take the Fast Path.
+
+| | **Full Loop** (§4) | **Fast Path** (§5) |
+|---|---|---|
+| **What** | New subsystems, new command sequences, new autos, structural changes | Constant changes, button bindings, small bug fixes, tuning tweaks |
+| **Steps** | Spec → Plan → Build → Review → Test → PR → Merge | Ask → Change → Verify → Commit |
+| **Plan mode?** | Yes | No |
+| **Written spec?** | Yes | One clear sentence is enough |
+| **Pull request?** | Always | Yes, but small PRs can bundle related tweaks |
+
+Rule of thumb: **if Claude is creating something, use the Full Loop. If Claude
+is adjusting something that already works, use the Fast Path.** When you're
+not sure, use the Full Loop — the extra ceremony is cheap; a broken robot is
+not.
+
+Either track, the safety rules never turn off. Claude still asks before
+touching gains, CAN IDs, offsets, inversions, current limits, or timeouts —
+that's enforced by the rules, not by which track you picked.
+
+---
+
+## 4. The Full Loop
+
+For building new code. Seven steps, ending in a pull request.
+
+```
+┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐
+│ 1 SPEC │─▶│ 2 PLAN │─▶│ 3 BUILD│─▶│ 4 REVIEW─▶│ 5 TEST │─▶│ 6 PR   │─▶│ 7 MERGE│
+│ (you)  │  │(you+AI)│  │  (AI)  │  │ (you)  │  │  (AI)  │  │(you+AI)│  │ (team) │
+└────────┘  └────────┘  └────────┘  └────────┘  └────────┘  └────────┘  └────────┘
+```
+
+### Step 1 — Spec: say what you want
+
+The more specific the detail, the better the result. A good spec answers:
+
+- **Behavior** — what should happen, in order, with numbers.
+  *"Spin up the flywheel, wait up to 1.5 s for it to reach setpoint, then feed."*
+- **Interfaces** — what it connects to.
+  *"Reads pose from RobotState. Bound to operator right bumper."*
+- **Done** — how you'll know it works.
+  *"Command activates/deactivates correctly in sim; tests pass."*
+
+**Constraints are optional.** The built-in rules (`CLAUDE.md` +
+`.claude/rules/`) already tell Claude what must not change — hard stops, risk
+tiers, architecture patterns. You only need to add a constraint when it's
+specific to this task (*"don't touch the pivot while doing this"*).
+
+Vague specs produce vague code. **"Make the shooter better" is not a spec.**
+"The shooter overshoots by ~200 RPM when spinning up from idle; reduce
+overshoot without slowing settling past 1.5 s" is a spec.
+
+For recurring tasks, don't write the spec from scratch — use the templates in
+`.claude/prompts/` (§9).
+
+### Step 2 — Plan: plan mode before code
+
+Start Claude in **plan mode** (`shift+tab` to cycle modes, or say "make a plan
+first"). Claude reads the code and proposes an approach but **cannot edit
+anything** until you approve.
+
+Plan mode is also where you pressure-test your own spec. Ask: *"What's unclear
+about this request? What could go wrong?"* It finds the holes in your spec
+faster than the compiler will.
+
+### Step 3 — Build: Claude implements, one logical change at a time
+
+Claude writes the code under the governance rules — they load automatically
+every session. What they guarantee:
+
+- It won't touch CAN IDs, PID gains, encoder offsets, inversions, current
+  limits, or safety timeouts without your explicit confirmation.
+- It states the behavioral consequence of every Medium+ risk change.
+- One logical change per response. If it starts "also cleaning up" things you
+  didn't ask for — stop it.
+
+**Your job during this step:** read what Claude *says*, not just the code.
+When it says *"this means the robot fires 0.2 s sooner if alignment isn't
+achieved"* — that sentence is the review. Decide if that's what you meant.
+
+### Step 4 — Review: a human reads every diff
+
+You are looking for (full list in `docs/review-checklist.md`):
+
+1. **Did it change only what was asked?** Extra "improvements" get reverted.
+2. **Do the numbers match the spec?** Timeouts, tolerances, setpoints, units.
+3. **Hard-stop items untouched?** CAN IDs, gains, offsets, inversions, limits.
+4. **Every `waitUntil` has a `.withTimeout()`.** A hung robot scores zero.
+5. **Commands are named** and hardware stays behind the IO interface.
+
+If you can't explain a line, ask Claude to explain it — that's half the point
+of reviewing. **Never approve code you don't understand.**
+
+### Step 5 — Test: Claude verifies, you spot-check
+
+Claude runs the whole verification ladder itself — build, unit tests, sim —
+and writes unit tests for the new logic automatically. Details in §8. Your
+part: watch the change work in AdvantageScope, in sim, with your own eyes.
+
+### Step 6 — Pull request
+
+Every Full Loop change goes to `main` through a pull request:
+
+- Work on a feature branch: `feature/...`, `fix/...`, `tune/...`
+- Run `/code-review` on the diff before opening the PR — it catches wrong
+  units, missing limits, and logic bugs for free.
+- Claude drafts the PR description; you read it — it's part of what you're
+  approving. The description says **why**, what the behavioral change is, and
+  how it was verified.
+- CI builds and format-checks every PR automatically. A red PR does not merge.
+
+### Step 7 — Merge
+
+Another team member (or a lead) reviews the PR before merge. Two humans have
+now read the change: the author and the reviewer. That's the standard.
+
+---
+
+## 5. The Fast Path
+
+For adjusting code that already works: constant changes, button bindings,
+small bug fixes, current limits, timeouts, and tuning tweaks. AI writes code
+fast and debugs well — the Fast Path gets out of its way.
+
+```
+ASK  ─▶  CHANGE  ─▶  VERIFY  ─▶  COMMIT (small PR)
+```
+
+1. **Ask** — one clear sentence with numbers.
+   *"Change the flywheel idle speed from 500 to 800 RPM — we measured spinup
+   taking too long from a dead stop."* No written spec, no plan mode.
+2. **Change** — Claude makes the edit. If the change touches a High-risk item
+   (gains, limits, timeouts), Claude will ask you to confirm and state the
+   failure mode — answer it; that's the process working.
+3. **Verify** — Claude still compiles, formats, and runs the tests. For a
+   behavior change it also checks in sim. "It's just a constant" is not an
+   excuse to skip verification — constants have types and consequences.
+4. **Commit** — one logical change, message says why. Related small tweaks
+   from one session (e.g., a tuning session's constant changes) can share a
+   branch and go up as one small PR.
+
+What makes the Fast Path safe isn't skipping steps — it's that the steps are
+small enough for Claude to run them in minutes and for you to review the diff
+in thirty seconds.
+
+**Escalate to the Full Loop** if a "small fix" turns out to touch more than a
+couple of files, changes a sequence's structure, or makes you say "while we're
+in here…" — that's a new feature wearing a bug fix's clothes.
+
+---
+
+## 6. The Season Arc
+
+The two tracks map onto how a season actually goes. Build season is Full Loop
+territory; competition season is mostly Fast Path.
+
+### Phase 1 — Initial robot spec (kickoff → robot exists)
+
+Write the spec for the whole robot: every mechanism, every motor, every
+sensor, every behavior. This is the biggest Full Loop work of the year, and
+it's where thoroughness pays off most — you are building the initial solution
+that everything else adjusts.
+
+**Include values you haven't tested yet.** Gear ratios from CAD, setpoints
+from napkin math, gains copied from last year, speeds from a game-piece video.
+Educated guesses and vibed-out numbers are fine — **you have to start with
+something**, and every guessed value is a one-line Fast Path fix later. Mark
+them: *"UNTESTED — estimate."*
+
+**Keep current limits low at first.** When testing brand-new code on a
+brand-new robot, low current limits mean a code bug stalls a mechanism
+harmlessly instead of breaking it. Raise limits deliberately, later, when the
+mechanism is proven — never as a first resort when something seems weak.
+
+### Phase 2 — Auto specs (robot drives → first competition)
+
+Spec each autonomous routine the same way: starting pose, path, actions at
+each point, time budget, what happens if a shot or pickup fails. Autos are
+Full Loop — they're new sequences, and a bad auto can foul or score zero.
+Verify every auto in sim (watch the pose trace on the field view) before it
+ever runs on carpet.
+
+### Phase 3 — Tuning and tweaking (forever)
+
+Everything after the robot works is mostly Fast Path: PID tuning, threshold
+adjustments, binding changes, bug fixes from match logs. The two skills built
+for this phase — `/pid-tune` and `/debug-match-log` (§9) — exist because
+tuning and log analysis were the two things we did most, all season.
+
+---
+
+## 7. Giving Claude Context
+
+The highest-leverage skill in this document. Claude's output quality tracks
+the quality of the context it gets.
+
+### What Claude already knows (automatic)
+
+| Source | What it provides |
+|---|---|
+| `CLAUDE.md` + `.claude/rules/` | Hard stops, risk tiers, architecture rules, build gates. Loads every session. |
+| `graphify` knowledge graph | A queryable map of the codebase — "what talks to what" without grepping. |
+| Persistent memory | Notes across sessions — ongoing tuning efforts, known issues, past decisions. |
+| The code itself | Claude reads any file it needs. Don't paste code it can just open. |
+
+### What YOU must supply (see §2 — the AI never sees the robot)
+
+1. **What physically happened.** *"The robot oscillated left-right during
+   auto-align at about 2 Hz"* beats *"auto-align is broken"* by a mile.
+2. **What changed recently.** New battery? Mechanical repair? Different
+   carpet? Claude sees the code history, not the pit.
+3. **The log file.** For any on-robot problem, the AdvantageKit log is worth
+   ten paragraphs. Run `/debug-match-log` with the log path and match time.
+4. **Intent and priority.** *"20 minutes before our next match, I need the
+   safest possible fix"* changes what Claude proposes. Say it.
+5. **Hardware ground truth.** Which robot (COMP vs ALPHA), what's plugged in,
+   what the mechanism looks like. A photo works — Claude reads images.
+
+### Context anti-patterns
+
+- **The mind-reader.** "Fix the intake." Which behavior? When? Instead of what?
+- **The novel.** Backstory burying the request. Lead with the ask.
+- **The stale session.** Hours across five topics — the vision debug bleeds
+  into the flywheel tune. One task per session (`/clear`).
+- **Screenshots of code.** Give file paths; Claude opens files itself.
+- **Paraphrased errors.** Paste the actual build output, verbatim.
+
+### The prompt pattern that covers 80% of requests
+
+```
+[WHAT]     Add jam detection to the intake roller.
+[BEHAVIOR] If stator current exceeds 60 A for more than 250 ms while the
+           intake command is active, stop the roller and log a warning.
+[WHERE]    IntakeRoller subsystem. Threshold constants in HardwareConstants.
+[VERIFY]   Show me it working in sim by faking a current spike in IOSim.
+```
+
+Four lines. Constraints only if this task needs one beyond the built-in rules.
+
+---
+
+## 8. Testing
+
+**Claude does the testing and verification. You spot-check the result.**
+"It compiles" is the floor, not the goal.
+
+### The ladder Claude runs on every change
+
+```bash
+./gradlew compileJava        # 1. It compiles. Always.
+./gradlew spotlessApply      # 2. Formatting (CI rejects unformatted code)
+./gradlew build              # 3. Full build + all unit tests
+./gradlew simulateJava       # 4. Simulation, for anything that moves or schedules
+```
+
+Claude runs all four itself before reporting a task complete, simulates the
+change, tries values, and reports what it observed — you should never have to
+ask "did you build it?"
+
+### Unit tests are automatic
+
+**Every piece of hardware-independent logic gets a unit test, and Claude
+writes it as part of the change — you don't have to ask.** Calculators,
+interpolation, zone math, alliance flipping, command sequencing, timeout
+behavior. And **every bug that ever bit us gets a regression test**: the fix
+isn't done until a test exists that fails on the old code and passes on the
+new. That's how a bug can only cost us once, ever, across all future seasons.
+
+Your job in testing is the part that needs game knowledge: the known-correct
+cases. *"At 3.0 m the shot table says 2400 RPM and 34°"* comes from real
+measurement — Claude turns it into a test. Review tests like code: a test
+that can't fail is not a test (ask Claude: *"show me this test failing"*).
+
+Tests live in `src/test/java`, never touch hardware, and run in CI on every
+PR.
+
+### Simulation — your spot-check
+
+Open **AdvantageScope**, connect to the sim, and watch the thing you changed
+actually happen:
+
+- **Commands** schedule and end when they should, with the right names
+  (this is why `.withName()` is mandatory — unnamed commands are invisible).
+- **Setpoints vs. measurements** on the same plot — oscillation and overshoot
+  are visible in sim before they're dangerous on carpet.
+- **Autos** — full routine in sim; a path that clips a wall in sim clips a
+  wall on the field.
+
+For driver-facing changes, sim with a real controller plugged in is a
+ten-minute test that has caught binding mistakes every single time.
+
+### Log replay — the superpower
+
+AdvantageKit records every input on the robot, so any match bug can be
+**replayed deterministically on a laptop** — same inputs, same code path,
+same bug, every time. Run `/debug-match-log` (§9): Claude reads the log,
+correlates inputs, outputs, and command state around the event, and proposes
+a root cause you can check against the replay.
+
+This is how the vision pose-jump bug got root-caused — from log data, not
+guessing. This capability is why `Logger.processInputs()` is a hard stop.
+
+### What each level catches
+
+| Level | Catches | Misses |
+|---|---|---|
+| Build | Type errors, formatting | Everything about behavior |
+| Unit tests | Wrong math, wrong units, regressions | Timing, integration |
+| Simulation | Command logic, sequencing, gross tuning, auto paths | Real friction, latency, batteries |
+| Log replay | Real-world bugs, exactly as they happened | Nothing — but only after the fact |
+| Drive practice | Everything else | Nothing — which is why it's last, not first |
+
+**Hardware time is the scarcest resource we have.** Every bug caught in sim is
+drive-practice time we get back.
+
+---
+
+## 9. Skills and Prompts
+
+The toolkit stays **small and curated on purpose.** A library of thirty
+templates nobody remembers is worse than eight that everyone knows. Before
+adding a new skill or prompt: does an existing one cover it? Once a season,
+the leads prune anything that hasn't been used.
+
+### Skills (slash commands — Claude runs the whole task)
+
+| Skill | What it does | When |
+|---|---|---|
+| `/debug-match-log` | Analyzes an AdvantageKit log: correlates signals around an anomaly, proposes root cause, sets up replay | Anything went wrong on the field |
+| `/pid-tune` | Runs the tuning loop: change gains → run sim → read the logs → evaluate → iterate; proposes final values with evidence | Tuning any closed-loop mechanism |
+| `/code-review` | Automated bug-hunting review of the current diff | Before every PR |
+| `/simplify` | Cleanup pass — reuse and simplification, no bug hunting | After a feature works, before PR |
+| `/verify` | Drives the change end-to-end (build + sim) instead of assuming | Nontrivial changes |
+| `/graphify` | Rebuild/query the codebase knowledge graph | After merging big changes |
+
+`/pid-tune` exists because PID tuning was the single task we repeated most.
+It sweeps or steps gains **in simulation**, reads the resulting logs itself,
+and iterates — the same loop a human tuner runs, without burning robot time.
+Real-robot gain changes still require your explicit confirmation, always.
+
+### Prompt templates (`.claude/prompts/` — you fill in brackets)
+
+| Template | Use when |
+|---|---|
+| `add-subsystem.md` | Scaffolding a new mechanism (Full Loop) |
+| `new-auto.md` | Creating or modifying an autonomous routine |
+| `tune-constants.md` | Applying **measured** values safely (Fast Path) |
+| `review-change.md` | Pre-merge safety review of a diff |
+| `write-test.md` | Locking in a behavior or bug as a JUnit test |
+
+**How to use one:** open the file, fill every `[BRACKET]`, delete lines that
+don't apply, paste. Don't freestyle a task that has a template — the template
+encodes every lesson from every time that task went wrong before.
+
+**When you repeat a task that has no template, that's a signal.** Write the
+template (fifteen minutes), or promote it to a skill if Claude can run the
+whole thing itself. Then tell a lead so it gets into this document. This is
+how the toolkit compounds year over year.
+
+---
+
+## 10. The IO Layer Pattern
+
+Adding a subsystem is the biggest Full Loop task and has the strictest
+structure. **Every mechanism follows this exact shape — no exceptions, no
+creativity.** The shape is what makes log replay, simulation, and AI
+generation all work.
+
+```
+subsystems/flywheel/
+├── io/
+│   ├── FlywheelIO.java        ← interface + @AutoLog inputs class
+│   ├── FlywheelIOReal.java    ← TalonFX code lives HERE and only here
+│   └── FlywheelIOSim.java     ← physics sim (or stubs), same interface
+├── Flywheel.java              ← logic only, zero hardware imports
+commands/
+└── FlywheelCommands.java      ← static command factories, all .withName()'d
+```
+
+**The one rule that matters:** hardware objects (`TalonFX`, `CANcoder`,
+`Pigeon2`…) exist ONLY inside `IOReal` classes. A motor import in a subsystem
+file breaks log replay for the whole robot — and log replay is how we've
+caught real match bugs.
+
+```java
+@Override
+public void periodic() {
+    io.updateInputs(inputs);
+    Logger.processInputs("Flywheel", inputs);   // NEVER remove this line
+    // ... logic reads from `inputs`, never from hardware
+}
+```
+
+### The recipe
+
+1. Get the hardware facts from whoever wired it: motor type, CAN ID, bus,
+   follower (and opposition), encoder, control mode.
+2. Fill in `.claude/prompts/add-subsystem.md` and paste. Claude generates all
+   five files from `template/`, adds the CAN ID to
+   `HardwareConstants.CanIds`, wires real/sim in `RobotContainer`, compiles,
+   and writes the unit tests.
+3. Review: CAN ID matches the wiring sheet; correct bus; config via
+   `PhoenixUtil.tryUntilOk(...)`; current limits set **low** (§6) and
+   enabled; `IOSim` works; inputs appear in AdvantageScope.
+4. First hardware test at low voltage before any closed-loop control.
+
+> [!IMPORTANT]
+> **Time cost: about 30 minutes including review.** Hand-writing the same five
+> files correctly used to take a day — and the sim implementation usually
+> didn't get written at all. This is the single clearest payoff of the whole
+> approach: the AI makes the *right structure* cheaper than the shortcut.
+
+### Changing an IO interface later
+
+Adding a field to an `@AutoLog` inputs class changes the log schema:
+**real + sim must both change in the same PR**, and the build regenerates the
+`*AutoLogged` class (`./gradlew clean generateSources` if it gets confused).
+Claude knows this rule — the reviewer checks both files changed.
+
+---
+
+## 11. Cheat Sheet
+
+**Two tracks:**
+- **Building new code?** Full Loop: Spec → Plan → Build → Review → Test → **PR** → Merge.
+- **Adjusting working code?** Fast Path: Ask → Change → Verify → Commit (small PR).
+- Not sure? Full Loop.
+
+**The spec pattern:**
+```
+[WHAT]     one sentence
+[BEHAVIOR] what happens, in order, with numbers
+[WHERE]    files/subsystems; where constants live
+[VERIFY]   how we'll prove it works
+```
+Constraints optional — the built-in rules cover the standard ones.
+
+**Claude runs the verification itself:** compile → spotless → build + unit
+tests → sim. It writes unit tests for new logic automatically, and a
+regression test for every bug fix. Your job: spot-check in AdvantageScope and
+supply the known-correct numbers.
+
+**The season arc:** ① initial robot spec (guessed values OK — mark them
+UNTESTED; keep current limits LOW) → ② auto specs (sim-verify every path) →
+③ tune and tweak (Fast Path + `/pid-tune` + `/debug-match-log`).
+
+**Skills:** `/debug-match-log` (field problems), `/pid-tune` (tuning loop),
+`/code-review` (before every PR), `/verify`, `/simplify`, `/graphify`.
+**Templates:** `.claude/prompts/` — add-subsystem, new-auto, tune-constants,
+review-change, write-test. Fill brackets, don't freestyle.
+
+**Never without explicit confirmation:** CAN IDs, PID/FF gains, encoder
+offsets, inversions, current limits, safety timeouts,
+`Logger.processInputs()`, `.auto` files.
+
+**Always:** every `waitUntil` gets `.withTimeout()`. Every command gets
+`.withName()`. Hardware only in `IOReal`. Every fixed bug gets a regression
+test. Every Full Loop change gets a PR.
+
+**Remember:** the AI knows the code, not the robot. Tell it what the robot
+is, what it did, and what you want — with numbers.
+
+**When in doubt:** treat it as one risk tier higher, use plan mode, and ask.
+
+---
+
+*Maintained by the programming leads alongside the playbook. This document
+outlives any one AI model — update the tools, keep the process. Last updated
+July 2026.*

--- a/docs/ai-development-playbook.md
+++ b/docs/ai-development-playbook.md
@@ -1,0 +1,274 @@
+# AI-Assisted Robot Development Playbook
+
+**Guerin Robotics — How We Program, Now and in Future Seasons**
+
+*A living document. Update it every postseason. Share it with anyone who asks "why do you let AI write your code?"*
+
+---
+
+## Executive Summary (read this page if you read nothing else)
+
+Our team programs robots the way modern engineering organizations build products: **humans decide what the robot should do and why; AI writes the implementation; humans review, simulate, and verify before anything touches the robot.**
+
+This is not a shortcut and it is not autopilot. It is a top-down engineering process — the same one used in aerospace and automotive: leadership writes specifications, implementation is delegated, and everything passes through review gates before it ships. The difference is that our "implementation team" is Claude, and it works in minutes instead of weeks.
+
+**Why this matters for us specifically:**
+
+- **Time is our scarcest resource.** An FRC season gives us roughly six weeks to build a competitive robot. Every hour a student spends hand-typing boilerplate subsystem code is an hour not spent on drive practice, strategy, mechanical iteration, or scouting. AI-assisted development compresses days of coding into hours — and gives those hours back to the things that actually win matches.
+- **We already know top-down engineering works — we lived it this year.** Our design side adopted the top-down methodology taught at [frcdesign.org](https://frcdesign.org/) — master layout first, subsystems inherit from it — and it made us dramatically better, fast. This playbook is the identical move applied to software: spec first, implementation derived from it, verification gates before anything ships. Software is the last place we're still building bottom-up.
+- **It is safer than unsupervised hand-written code, not less safe.** Our AI operates under a written governance framework with hard stops (it cannot change CAN IDs, PID gains, encoder offsets, or safety timeouts without explicit human confirmation), mandatory build verification, and human review of every change. Most student code has none of that.
+- **This is where the industry already is.** Anthropic, Google, Microsoft, and virtually every serious software organization now develop this way. Students who learn to specify, direct, review, and verify AI-generated systems are learning the actual job of a modern engineer. Students who only learn to hand-type Java are training for a version of the job that is disappearing.
+
+**The ask:** adopt this playbook as our standard programming process, teach it to every new student, and improve it every season. This is not a plan for one good year — it is the operating system of a program that stays at the top as students come and go, because the rules, templates, and documentation compound instead of graduating. Teams that adopt this will out-iterate teams that don't.
+
+---
+
+## 1. The Core Idea: Top-Down, Specification-Driven Engineering
+
+Traditional student programming is bottom-up: open the editor, start typing, debug until it works. It's slow, the quality depends entirely on who typed it, and knowledge leaves when that student graduates.
+
+We've already seen what happens when you flip this. This year our design side adopted the top-down workflow taught at [frcdesign.org](https://frcdesign.org/) — the community design handbook used by top FRC teams: define the robot's architecture in a master layout sketch first, then let every subsystem inherit from it instead of CADing parts in isolation and hoping they fit. It transformed how we build — fewer integration surprises, faster iteration, a much better robot. Nobody on this team argues with top-down design anymore, and nobody calls it cheating or says it takes the fun out of engineering.
+
+**This playbook is the exact same move, applied to software.** The parallel is not a metaphor — it's the identical discipline, step for step:
+
+| Top-down CAD (frcdesign.org) | Top-down software (this playbook) |
+|---|---|
+| Master layout sketch defines the robot | Written spec defines the behavior |
+| Subsystems inherit from the layout | Code is generated from the spec |
+| Interference checks in the assembly | Build checks + simulation before deploy |
+| Design reviews before manufacturing | Human review of every diff |
+| Part libraries reused every season | Templates, rules & skills reused every season |
+
+We already proved on this team, this year, that flipping from bottom-up to top-down makes us dramatically better. Software is simply the last place we're still building bottom-up. Fixing that is the same win we already banked on the design side.
+
+The process has five layers, and **humans own four of them:**
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ 1. STRATEGY (humans)                                    │
+│    What does the robot need to do to win matches?       │
+├─────────────────────────────────────────────────────────┤
+│ 2. SPECIFICATION (humans)                               │
+│    Written spec: behaviors, constraints, tolerances,    │
+│    failure modes, what "done" means                     │
+├─────────────────────────────────────────────────────────┤
+│ 3. IMPLEMENTATION (Claude)                              │
+│    Code written to the spec, under governance rules,    │
+│    following our architecture                           │
+├─────────────────────────────────────────────────────────┤
+│ 4. REVIEW & VERIFICATION (humans + tools)               │
+│    Human code review, compile checks, simulation,       │
+│    log replay — nothing skips the gates                 │
+├─────────────────────────────────────────────────────────┤
+│ 5. ROBOT TESTING (humans)                               │
+│    Real hardware, drive practice, match validation      │
+└─────────────────────────────────────────────────────────┘
+```
+
+The skill we cultivate is **layer 2**: writing specifications precise enough that the implementation is almost mechanical. That is a harder and more valuable skill than typing code. A student who can write "the shooter must reach setpoint within 1.5 seconds, and if alignment isn't achieved within the remaining budget, fire anyway — a robot that hangs mid-sequence scores zero points" understands the system. A student who can type a `PIDController` constructor from memory understands syntax.
+
+**We direct. Claude types. We verify.** That's the whole model.
+
+And "Claude types" undersells it. Claude isn't only the layer-3 implementer we visit once — it's an **agent of the team we direct across the whole process.** In **plan mode** it helps pressure-test strategy and sharpen a spec before a line of code is written; it drafts the implementation; it explains and helps review the resulting diff; it debugs from logs. Humans still *own* four of the five layers — every decision is ours — but the AI is a working member of the team we steer at every step, not a code vending machine.
+
+### What a spec looks like
+
+A spec is not an essay. It's a structured request:
+
+- **Behavior:** what should happen, in sequence, with numbers ("spin up flywheel, wait for alignment up to 0.9s, then feed")
+- **Constraints:** what must not change ("do not touch the drive subsystem; timeout constants live in `CompConstants.Waits`")
+- **Interfaces:** what it connects to ("reads pose from `RobotState`, triggered by the operator's right bumper")
+- **Verification:** how we'll know it works ("must show correct command activation in sim before deploy")
+
+We keep reusable spec templates in `.claude/prompts/` — add a subsystem, tune constants, build an auto, debug a match log, review a change. Filling one out takes ten minutes. The implementation comes back in minutes more.
+
+---
+
+## 2. The Case: Time, Capability, and Competitiveness
+
+### Time
+
+The math is blunt. A traditional FRC software timeline looks like: weeks 1–3 writing subsystems, weeks 4–5 getting autonomous barely working, week 6 panic. Software is chronically the bottleneck — the mechanical robot sits idle waiting for code.
+
+With this process, subsystem scaffolding takes hours, not weeks. That moves the bottleneck off software entirely. The season's schedule becomes: robot code ready when the robot is, then **weeks of drive practice and autonomous refinement** — which is where matches are actually won. Ask any veteran team what they'd trade for three extra weeks of drive practice.
+
+### Capability — what a team working this way can do
+
+These are the kinds of work AI-assisted engineering delivers today. This is the ceiling we'd be raising:
+
+| Capability | Typical team | With this process |
+|---|---|---|
+| Scaffold every subsystem from the spec while the robot is still in CAD — code-complete in simulation before the robot exists | Weeks 1–3 of the season | Week 1 |
+| Convert an entire autonomous library between path-planning frameworks, physics config and all | Days to weeks of tedious, error-prone manual conversion | One session |
+| Root-cause a vision or odometry bug by replaying match logs deterministically on a laptop | Often never solved — teams live with "the robot teleports sometimes" | One debugging session |
+| Extract real drivetrain dynamics from match telemetry and tune auto-aim with proper feedforward — actual system identification | Most teams guess at gains | Measured, sim-validated |
+| Build ambitious features like shoot-on-the-move that veteran teams spend seasons chasing | Out of reach | On the table |
+| Run a full-codebase review that catches latent bugs — wrong units, missing limits — before they cost a match | Rarely done at all | Routine |
+| Debrief every match from its log and fix anomalies before the next one | "It felt weird out there" | Data by next match |
+
+Notice what these have in common: the AI doesn't just type faster — it brings **depth** (system identification, log-replay debugging, whole-codebase review) that a typical student team simply doesn't have access to at any price. It's like having a professional controls engineer and a senior code reviewer on call, 24/7, during build season.
+
+### Institutional memory
+
+Student teams lose their best programmer every year to graduation. Our process captures knowledge in files that persist: the governance rules, the architecture docs, the spec templates, a knowledge graph of the entire codebase, and this playbook. A new student in a future season inherits not just code, but the *documented reasoning* behind it — and an AI that has read all of it and can answer questions about any part of the robot. The bus factor of a traditional team is one student. Ours is zero.
+
+---
+
+## 3. Answering the Concerns — Honestly
+
+These objections deserve real answers, not dismissal. Here they are.
+
+### "The code won't be accurate or reliable."
+
+This is the most important concern, and the answer is: **reliability comes from process, not from who typed the code.** Hand-written student code is not reliable by default either — every team has stories of the auto that drove into a wall because of a sign error at midnight.
+
+Our reliability comes from gates that apply to *all* code regardless of author:
+
+1. **Written governance.** Claude operates under a rules file (`CLAUDE.md` plus safety rules) that it reads before every session. It is *prohibited* from touching CAN IDs, encoder offsets, PID gains, motor inversions, current limits, or safety timeouts without explicit human confirmation. It must classify every change by risk level and state the behavioral consequence and failure mode of risky changes before making them.
+2. **Everything compiles and builds** before it's delivered. Automated formatting and build checks are mandatory steps, not suggestions.
+3. **Human review of every diff.** A human reads and approves every change. The AI is required to explain what changed and why in plain language, which makes review *easier* than reviewing a teammate's uncommented 2 a.m. code.
+4. **Simulation before hardware.** Command logic and state changes get verified in simulation with full logging before deploy.
+5. **Log replay.** Our architecture (AdvantageKit) records every input; any match bug can be replayed deterministically on a laptop. When something goes wrong, we don't guess — we reproduce it exactly and fix it.
+
+Compare that to the traditional baseline and ask which process you'd trust on a 120-pound robot.
+
+One more honest point: yes, AI makes mistakes. So do students and mentors. The question was never "is the author infallible" — it's "does the process catch mistakes before the match." Ours does, by design.
+
+### "Students won't learn anything. This takes the fun out of it."
+
+This assumes the valuable skill is typing code. It isn't — and it hasn't been for a while.
+
+What students learn in this process:
+
+- **Systems thinking** — you cannot write a good spec without understanding how the flywheel, hood, transport, vision, and drivetrain interact. Spec-writing forces deeper understanding than copy-pasting a subsystem from last year ever did.
+- **Reading and reviewing code** — students review every AI-generated diff. Code *reading* is a rarer and more valuable skill than code writing, and reviewing well-structured, explained code is one of the fastest ways to learn what good code looks like. The AI will explain any line, at any depth, with infinite patience. It is the best programming tutor a student has ever had access to.
+- **Verification engineering** — designing the test that proves it works, running the sim, reading the logs.
+- **Directing AI** — which, bluntly, is the defining skill of the next twenty years of engineering careers. FIRST's own mission is preparing students for real STEM careers. Real STEM careers now look like this.
+
+And the fun: ask a student whether the fun of robotics is typing `private final TalonFX motor;` for the fortieth time — or watching a shoot-on-the-move feature they specified actually work at drive practice three days after they thought of it. AI removes the *drudgery*, not the engineering. The ideas, the strategy, the "what if the robot could..." — that all stays human, and there's dramatically more time for it.
+
+**Also, nobody is banned from writing code.** A student who wants to hand-write a subsystem to learn is welcome to — and can have the AI review it, explain it, and pair with them. The policy is about how the *team ships*, not about forbidding anyone from learning however they want.
+
+### "It's cheating / against the spirit of FIRST."
+
+FRC rules permit any development tools, including AI assistance — the same as teams using vendor libraries, CAD generative design, or example code from Chief Delphi (which every team does). The code is team-owned, team-reviewed, team-understood, and team-maintained. What FIRST actually celebrates is *Gracious Professionalism* and real-world engineering practice — and this **is** real-world engineering practice, as of right now, at essentially every major software company.
+
+There's also a leadership angle: a first-year team demonstrating a disciplined, documented, safety-governed AI development process is exactly the kind of innovation that awards judges and other teams take notice of. This playbook itself is shareable — helping other teams adopt this well *is* the spirit of FIRST.
+
+### "We'll become dependent on it and helpless without it."
+
+We are "dependent" on WPILib, vendor motor libraries, CAD software, and calculators too. The relevant question is whether the team *understands its robot* — and our process forces more understanding, not less, because every change requires a human-written spec going in and a human review coming out. The knowledge lives in our documented architecture, our rules files, and our students' heads. If AI vanished tomorrow, we'd have an exceptionally well-documented codebase and students who deeply understand its structure — better positioned than most teams, not worse.
+
+### "What if it does something dangerous to the robot?"
+
+This is exactly why the governance framework exists, and it's worth reading (`CLAUDE.md` and `.claude/rules/` in the repository). The hard-stop list was written from a catalog of real failure modes: wrong CAN ID controls the wrong motor, wrong inversion makes swerve fight itself, missing timeout hangs the robot mid-match. The AI is required to refuse those changes without explicit confirmation, escalate anything uncertain to a higher risk tier, and state failure modes out loud before high-risk edits. **No mentor has ever imposed this level of discipline on student-written code.** The AI-governed process is the most safety-conscious programming process this team could run.
+
+### "AI code is unmaintainable spaghetti."
+
+Not under this playbook, because the governance rules enforce our architecture: hardware isolated behind IO interfaces, a single state singleton, named command factories, one logical change per commit, no opportunistic refactors. The AI follows written rules more consistently than humans do — it never gets tired at 11 p.m. and hard-codes a CAN ID "just for now." Spaghetti comes from having no standards; this process is *made of* standards.
+
+---
+
+## 4. The Guardrails (why you can trust this)
+
+For skeptics, this section is the whole ballgame. Our AI does not free-wheel. Everything runs inside a written, version-controlled governance framework that lives in the repository itself:
+
+- **`CLAUDE.md`** — the constitution. Identity ("preserve working behavior; skepticism about changes is correct"), hard stops, and a five-tier risk classification (Safe → Low → Medium → High → Blocked) with escalating requirements. When uncertain, the AI must treat a change as one tier riskier.
+- **`.claude/rules/00-safety.md`** — the failure-mode catalog and the absolute hard stops (CAN config, control gains, current limits, safety interlocks, logging integrity).
+- **`.claude/rules/01–05`** — architecture rules, hardware/CAN rules, command patterns, mandatory build verification, git discipline. These encode *why* past decisions were made so they don't get silently reversed.
+- **Review checklist and change classification docs** — so human reviewers know exactly what to look for at each risk tier.
+- **Tested against the spec.** Automated code review, security review, and end-to-end verification run against the written spec before a human ever looks — more testing and verification than this team ever did by hand.
+- **One logical change per response; small diffs; no scope creep.** Enforced in the rules.
+
+Every future season, the first postseason task is updating these files with what we learned. The governance framework is itself a year-over-year asset — arguably our most valuable one.
+
+---
+
+## 5. The Toolkit
+
+### What we run today
+
+| Tool | What it does for us |
+|---|---|
+| **Claude Code** | The core agent: reads the whole codebase, writes code, runs builds, analyzes logs, executes multi-step engineering tasks under our governance rules |
+| **Governance framework** (`CLAUDE.md` + rules) | Safety rails, architecture enforcement, risk classification — see §4 |
+| **Prompt templates** (`.claude/prompts/`) | Reusable specs: add-subsystem, new-auto, tune-constants, review-change, write-test. Standardizes how we direct the AI |
+| **Team skills** (`/debug-match-log`, `/pid-tune`) | The two most-repeated tasks, fully automated: match-log root-cause analysis and the sim-based PID tuning loop |
+| **graphify knowledge graph** | A queryable map of the entire codebase — components, relationships, architecture. Lets the AI (and students) answer "what talks to what" instantly instead of grepping |
+| **Code review skills** (`/code-review`, `/security-review`, `/simplify`) | On-demand automated review passes — including multi-agent deep review of a whole branch before merge |
+| **Verification skill** (`/verify`) | Drives a change end-to-end (build, sim) instead of assuming it works |
+| **Subagents** | Parallel workers for big tasks — one can explore the codebase while another plans an implementation |
+| **AdvantageKit + log replay** | Not an AI tool per se, but the foundation that lets the AI debug matches deterministically from logs |
+
+### What we can add next
+
+- **Custom team skills** — e.g., a `/new-auto` skill that takes a path description and produces a Choreo trajectory plus registered named commands; a `/match-debrief` skill that ingests a match log and produces a findings report automatically after every match.
+- **CI integration** — every pull request automatically built, formatted, and AI-reviewed on GitHub before a human ever looks at it.
+- **Scheduled agents** — nightly automated codebase health review during build season; automatic post-practice log analysis.
+- **MCP integrations** — connect the AI to our Slack (post build results to the team channel), scouting data, or match schedules.
+- **Vision/CAD assistance** — AI-assisted analysis of camera calibration, field layouts, and mechanism geometry from images.
+- **A student onboarding skill** — new programmer joins, runs one command, gets a guided interactive tour of the robot code.
+
+The toolkit compounds. Every skill we build this year is inherited by every future season.
+
+---
+
+## 6. The Year-Over-Year Season Layout
+
+This is the repeatable process. Each season, run this loop:
+
+### Preseason (fall)
+1. **Update the governance files** with last season's lessons (new hard stops, new failure modes, architecture decisions).
+2. **Train new students** on the process: how to write a spec, how to review a diff, how to run sim verification. Target: every programming student can independently spec-and-ship a low-risk change by kickoff.
+3. **Refresh the toolkit** — update Claude Code, rebuild the knowledge graph, add the skills identified last postseason.
+4. **Dry run**: rebuild a past-season subsystem from spec alone, as a training exercise.
+
+### Kickoff → Week 1
+1. Strategy team defines robot behaviors (human work — the most important week of the year).
+2. Programming leads write the **robot software spec**: subsystem list, state machine, autonomous priorities, interfaces to hardware.
+3. Claude scaffolds every subsystem from the spec + template while mechanical design is still in CAD. **Software is code-complete in simulation before the robot exists.**
+
+### Build Season (weeks 2–6)
+The loop, repeated per feature: **Spec → Implement (AI) → Review (human) → Simulate → Deploy → Drive-test.** One logical change at a time, every change through the gates. Autonomous routines developed and tuned in simulation continuously, not crammed into week 5.
+
+### Competition
+- Match logs pulled after every match; AI-assisted debrief finds anomalies before the next match.
+- Fixes at competition follow the same gates, compressed — spec can be verbal, but review and build verification never skip. Revert discipline per the git rules.
+
+### Postseason
+1. Full AI-assisted codebase review to catch latent bugs while there's time to fix them calmly.
+2. **Post-mortem into the governance files** — every mistake becomes a rule so it can't recur.
+3. Update this playbook.
+4. Archive the season's knowledge graph and docs as the starting context for next year.
+
+---
+
+## 7. How This Fits GRIDS
+
+GRIDS is our own framework — **G**oals, **R**ecruitment, **I**ntegration, **D**evelopment, **S**uccession. This playbook isn't a side project bolted onto the team; it puts a spec-driven software engine behind every pillar.
+
+| Pillar | How the playbook advances it |
+|---|---|
+| **Goals** — world-class robots, competing at the highest level | AI-assisted, spec-driven development is the largest legal time multiplier available to reach that level — and to keep reaching it, year after year. |
+| **Recruitment** — inspire and attract the next generation | A disciplined, documented, safety-governed AI process is exactly what awards judges and prospective members notice. Sharing this playbook with other teams is the spirit of FIRST. |
+| **Integration** — meaningful work from day one | A new member paired with a veteran can spec-and-ship a real low-risk change in their first week. The rules and templates make the codebase approachable instead of intimidating. |
+| **Development** — grow students into engineers | The skill we cultivate is specifying systems — behaviors, numbers, constraints, what "done" means. That is real engineering judgment, and it transfers to CAD, electrical, and strategy. |
+| **Succession** — leave the team stronger than we found it | Most teams reset every June when their best programmer graduates. Here the rules, templates, skills, and docs *are* the program — they compound, and each season starts where the last one ended. |
+
+The through-line: this is not a tool one talented student uses. It's an institution the whole team owns, and it makes every pillar of GRIDS stronger the longer we run it.
+
+---
+
+## 8. What This Means for Us
+
+Time is our biggest enemy. Every team gets the same six weeks; the teams that win are the ones that spend those weeks iterating on the robot instead of fighting their tools. AI-assisted development is the single largest time multiplier available to an FRC team today, it is fully legal, and almost nobody is using it with real discipline yet. That is a competitive window, and it will not stay open — in three years this will simply be how good teams work, the way swerve went from exotic to mandatory.
+
+We can be early and disciplined, build the playbook, win with it, and teach it — or we can be late and copy someone else's version of this document.
+
+And this is not about one season. Most teams reset every June when their best programmer graduates and the knowledge walks out the door. Under this playbook nothing resets: the governance rules, the spec templates, the skills, and the documentation *are* the program, and they compound. Top-down design already transformed how we build the robot — we watched it happen this year. This finishes the job on the software side, and it's how a first-year team becomes a top team that stays on top.
+
+The framework is written. The tools are installed. The only missing piece is **us** — the whole team choosing to adopt it, learn it, and make it how we build. Full buy-in is the last component, and it's the one only we can supply.
+
+---
+
+*Maintained by the programming leads. Last updated July 2026. Questions and pushback welcome — this document gets stronger when it has to answer them, and so does the process.*


### PR DESCRIPTION
## Summary
- Restores `docs/ai-development-playbook.md` and `docs/ai-development-handbook.md`, which were untracked files accidentally lost when a stash was dropped during a workspace cleanup.
- Recovered from the dangling stash commit's tree before it could be garbage-collected; content is unchanged from the original.

## Test plan
- [x] Verified file contents match original (line counts: handbook 559, playbook 274)
- [x] No code changes — docs only