### PR TITLE
Boost drive slip current in auto, reset for teleop

### DIFF
--- a/src/main/java/frc/robot/HardwareConstants.java
+++ b/src/main/java/frc/robot/HardwareConstants.java
@@ -1,6 +1,7 @@
 package frc.robot;
 
 import static edu.wpi.first.math.util.Units.inchesToMeters;
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.RPM;
 import static edu.wpi.first.units.Units.Rotations;
@@ -9,6 +10,7 @@ import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Voltage;
 import frc.lib.AllianceFlipUtil;
 
@@ -118,6 +120,14 @@ public class HardwareConstants {
 
     public static class Autos {
       public static final String DefaultAutoName = "2.5-Left-Comp";
+    }
+
+    // Drive motor slip current (stator/torque current limit). Boosted for autonomous path
+    // following; teleopSlipCurrent must match COMP_TunerConstants.kSlipCurrent, the validated
+    // boot-time default.
+    public static class Currents {
+      public static final Current autoSlipCurrent = Amps.of(120);
+      public static final Current teleopSlipCurrent = Amps.of(80);
     }
   }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -180,6 +180,10 @@ public class Robot extends LoggedRobot {
   public void autonomousInit() {
     autonomousCommand = robotContainer.getAutonomousCommand();
 
+    // Boost drive slip current for autonomous path following; reset to the tuned/validated
+    // value in teleopInit(). Called once per mode transition, not from a periodic loop.
+    robotContainer.setDriveSlipCurrent(HardwareConstants.CompConstants.Currents.autoSlipCurrent);
+
     // schedule the autonomous command (example)
     if (autonomousCommand != null) {
       CommandScheduler.getInstance().schedule(autonomousCommand);
@@ -207,6 +211,9 @@ public class Robot extends LoggedRobot {
     }
     CommandScheduler.getInstance().schedule(robotContainer.getAutoStopCommand());
     HubShiftUtil.initialize();
+
+    // Reset drive slip current to the tuned/validated teleop value (see autonomousInit()).
+    robotContainer.setDriveSlipCurrent(HardwareConstants.CompConstants.Currents.teleopSlipCurrent);
 
     // Apply the selected driver preset once per teleop enable. Reading the chooser/NT
     // values in the drive loop saturated the RIO CPU — keep this out of periodic code.

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -21,6 +21,7 @@ import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -1326,6 +1327,11 @@ public class RobotContainer {
   public Command getAutoStopCommand() {
     return ShootSequences.stopAll(
         flywheel, prestage, hood, upperFeeder, lowerFeeder, transport, intakeRoller);
+  }
+
+  /** Sets the drive motors' slip current on all modules. Call once per mode transition. */
+  public void setDriveSlipCurrent(Current slipCurrent) {
+    drive.setSlipCurrent(slipCurrent);
   }
 
   public Command getIntakeRollerCommand() {

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -45,6 +45,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.Constants;
 import frc.robot.Constants.Mode;
+import frc.robot.HardwareConstants;
 import frc.robot.Robot;
 import frc.robot.RobotState;
 import frc.robot.generated.TunerConstants;
@@ -80,6 +81,10 @@ public class Drive extends SubsystemBase {
   private static final double ROBOT_MASS_KG = 63.503;
   private static final double ROBOT_MOI = 5.162;
   private static final double WHEEL_COF = 1.2;
+  // Modeled on the boosted auto slip current (see Robot.autonomousInit()/teleopInit()) since
+  // PP_CONFIG's dynamics model is used for autonomous path following and on-the-fly pathfinding.
+  // Note: teleop-triggered pathfinding (e.g. Drive.alignForDefenseShot()) will use this same
+  // 120A-modeled feasibility even though the hardware is reconfigured to 80A in teleop.
   private static final RobotConfig PP_CONFIG =
       new RobotConfig(
           ROBOT_MASS_KG,
@@ -90,7 +95,7 @@ public class Drive extends SubsystemBase {
               WHEEL_COF,
               DCMotor.getKrakenX60Foc(1)
                   .withReduction(TunerConstants.FrontLeft.DriveMotorGearRatio),
-              TunerConstants.FrontLeft.SlipCurrent,
+              HardwareConstants.CompConstants.Currents.autoSlipCurrent.in(Amps),
               1),
           getModuleTranslations());
 

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -35,6 +35,7 @@ import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj.DriverStation;
@@ -316,6 +317,17 @@ public class Drive extends SubsystemBase {
     }
     kinematics.resetHeadings(headings);
     stop();
+  }
+
+  /**
+   * Sets the drive motors' slip current (stator/torque current limit) on all four modules. Call
+   * once on a mode transition (e.g. autonomousInit/teleopInit) — not from a periodic loop.
+   */
+  public void setSlipCurrent(Current slipCurrent) {
+    double slipCurrentAmps = slipCurrent.in(Amps);
+    for (var module : modules) {
+      module.setSlipCurrent(slipCurrentAmps);
+    }
   }
 
   public void alignForDefenseShot(Pose2d targetPose) {

--- a/src/main/java/frc/robot/subsystems/drive/Module.java
+++ b/src/main/java/frc/robot/subsystems/drive/Module.java
@@ -94,6 +94,11 @@ public class Module {
     io.setTurnOpenLoop(0.0);
   }
 
+  /** Sets the drive motor's slip current (stator/torque current limit) in amps. */
+  public void setSlipCurrent(double slipCurrentAmps) {
+    io.setSlipCurrent(slipCurrentAmps);
+  }
+
   /** Returns the current turn angle of the module. */
   public Rotation2d getAngle() {
     return inputs.turnPosition;

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIO.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIO.java
@@ -46,4 +46,7 @@ public interface ModuleIO {
 
   /** Run the turn motor to the specified rotation. */
   public default void setTurnPosition(Rotation2d rotation) {}
+
+  /** Sets the drive motor's slip current (stator/torque current limit) in amps. */
+  public default void setSlipCurrent(double slipCurrentAmps) {}
 }

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFX.java
@@ -266,12 +266,16 @@ public class ModuleIOTalonFX implements ModuleIO {
 
   @Override
   public void setSlipCurrent(double slipCurrentAmps) {
+    // Refresh from the device first so fields we don't touch here (e.g. TorqueNeutralDeadband,
+    // SupplyCurrentLimit) aren't reset to config-object defaults when we apply.
     var torqueCurrentConfig = new TorqueCurrentConfigs();
+    tryUntilOk(5, () -> driveTalon.getConfigurator().refresh(torqueCurrentConfig));
     torqueCurrentConfig.PeakForwardTorqueCurrent = slipCurrentAmps;
     torqueCurrentConfig.PeakReverseTorqueCurrent = -slipCurrentAmps;
     tryUntilOk(5, () -> driveTalon.getConfigurator().apply(torqueCurrentConfig, 0.25));
 
     var currentLimitsConfig = new CurrentLimitsConfigs();
+    tryUntilOk(5, () -> driveTalon.getConfigurator().refresh(currentLimitsConfig));
     currentLimitsConfig.StatorCurrentLimit = slipCurrentAmps;
     currentLimitsConfig.StatorCurrentLimitEnable = true;
     tryUntilOk(5, () -> driveTalon.getConfigurator().apply(currentLimitsConfig, 0.25));

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFX.java
@@ -12,7 +12,9 @@ import static frc.robot.util.PhoenixUtil.*;
 import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.CANcoderConfiguration;
+import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.configs.TorqueCurrentConfigs;
 import com.ctre.phoenix6.controls.PositionTorqueCurrentFOC;
 import com.ctre.phoenix6.controls.PositionVoltage;
 import com.ctre.phoenix6.controls.TorqueCurrentFOC;
@@ -260,5 +262,18 @@ public class ModuleIOTalonFX implements ModuleIO {
           case TorqueCurrentFOC -> positionTorqueCurrentRequest.withPosition(
               rotation.getRotations());
         });
+  }
+
+  @Override
+  public void setSlipCurrent(double slipCurrentAmps) {
+    var torqueCurrentConfig = new TorqueCurrentConfigs();
+    torqueCurrentConfig.PeakForwardTorqueCurrent = slipCurrentAmps;
+    torqueCurrentConfig.PeakReverseTorqueCurrent = -slipCurrentAmps;
+    tryUntilOk(5, () -> driveTalon.getConfigurator().apply(torqueCurrentConfig, 0.25));
+
+    var currentLimitsConfig = new CurrentLimitsConfigs();
+    currentLimitsConfig.StatorCurrentLimit = slipCurrentAmps;
+    currentLimitsConfig.StatorCurrentLimitEnable = true;
+    tryUntilOk(5, () -> driveTalon.getConfigurator().apply(currentLimitsConfig, 0.25));
   }
 }


### PR DESCRIPTION
## Summary
- Adds `ModuleIO.setSlipCurrent()` (real TalonFX hardware only) and wires it through `Module`/`Drive`/`RobotContainer` so the drive motors' stator/torque current limit can be reconfigured live.
- `Robot.autonomousInit()` boosts slip current to 120A; `Robot.teleopInit()` resets it to the validated 80A. Both calls happen once per mode transition (never in a periodic loop), so there's no added RIO 2.0 CPU load.
- `Drive.PP_CONFIG` (PathPlanner's RobotConfig dynamics model) now reflects the 120A auto value instead of the static 80A `TunerConstants.FrontLeft.SlipCurrent`, so autonomous path following and on-the-fly pathfinding plan against the current actually available in auto.

## Behavioral notes
- `COMP_TunerConstants.kSlipCurrent` is untouched — the robot still boots at the safe 80A default before any mode is selected.
- `Drive.alignForDefenseShot()` (teleop-triggered pathfinding via driver buttons) now plans against the 120A-modeled `PP_CONFIG` even though the hardware is reconfigured back to 80A in teleop. This should just mean the PID feedback term works a little harder to catch up on that one alignment move, not a hard failure, but worth confirming on the practice field before comp.

## Test plan
- [ ] `./gradlew compileJava` / `spotlessCheck` pass (done locally)
- [ ] Sim/practice-field check: verify slip current actually reconfigures to 120A on `autonomousInit()` and back to 80A on `teleopInit()` (check `Drive/Module*/DriveCurrentAmps` in AdvantageScope)
- [ ] Practice-field check: confirm `alignForDefenseShot()` tracking behavior in teleop is still acceptable with the 120A-modeled `PP_CONFIG`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic drive slip-current tuning for autonomous and teleoperated modes.
  - Autonomous mode now uses a higher 120A limit, while teleoperated mode uses an 80A limit.
  - Drive motor current settings are applied across all swerve modules when switching modes.

- **Bug Fixes**
  - Improved drivetrain behavior by applying mode-specific motor current limits consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->