### PR TITLE
Match the drive-controller chooser to Driver Presets, move trench align to Xbox X

### DIFF
--- a/docs/drive-controller-mode.md
+++ b/docs/drive-controller-mode.md
@@ -31,8 +31,8 @@ gets unplugged and replugged it can land on a different port, and the symptom is
 
 ## 2. Elastic setup (do this once, then save the layout)
 
-Three widgets, all under **SmartDashboard**. They are published as soon as robot code
-starts, so you don't need to enable to see them.
+One widget, under **SmartDashboard**. It is published as soon as robot code starts, so
+you don't need to enable to see it.
 
 1. Open Elastic and connect to the robot (gear icon → team number 10021).
 2. Go to the **Teleoperated** tab — the code auto-selects this tab on enable, so this
@@ -42,11 +42,12 @@ starts, so you don't need to enable to see them.
 | Key | Widget type | Shows |
 |---|---|---|
 | `DRIVE CONTROLLER` | ComboBox Chooser (automatic) | the dropdown you pick from |
-| `DRIVE NEXT ENABLE` | Text Display | what will drive at the next enable |
-| `DRIVING NOW` | Text Display | what is driving right now |
 
-4. Stack them vertically in that order. Make `DRIVING NOW` the largest — it is the one
-   that answers "which controller do I pick up."
+4. **Optional but recommended.** The dropdown shows what you *requested*, not what the
+   robot is actually running. To see the latched value, add **NetworkTables →
+   AdvantageKit → RealOutputs → `driveController`** as a Boolean Box: `true` = Xbox is
+   driving, `false` = flightstick. It only changes at enable, so it is the honest answer
+   to "which controller do I pick up."
 5. **Save the layout** (Ctrl+S / File → Save Layout) or you will rebuild this at the event.
 
 ---
@@ -58,18 +59,20 @@ Do this with the robot **disabled**.
 1. Pick the incoming driver's controller from the `DRIVE CONTROLLER` dropdown:
    - `FLIGHTSTICK Drive (normal)`
    - `XBOX CONTROLLER Drive`
-2. Watch `DRIVE NEXT ENABLE`. Within a moment it should name the controller you picked.
-   If it does not change, the dashboard is not connected to the robot — fix that first.
-3. Enable teleop. `DRIVING NOW` updates to match.
+2. Confirm the dropdown now reads your choice. If it snaps back or does not respond, the
+   dashboard is not connected to the robot — fix that first.
+3. Enable teleop. The selection latches at that moment.
 
 ### The one rule
 
-> **`DRIVING NOW` and `DRIVE NEXT ENABLE` must say the same thing before the match starts.**
+> **The dropdown is a request. It does not take effect until the next enable.**
 
-If they disagree, the change has not taken effect yet. Disable and re-enable.
+Change it while already enabled and the robot keeps running the old scheme for the rest
+of that enable. Disable and re-enable to apply it.
 
-They only disagree in the window between changing the dropdown and the next enable —
-which is exactly the state worth catching.
+If you added the optional `driveController` boolean box from section 2, it shows the
+latched value — it will disagree with the dropdown in exactly that window, which is the
+state worth catching.
 
 ### Why the change doesn't apply immediately
 
@@ -82,18 +85,18 @@ next disable → enable.
 
 ## 4. What happens after a brownout or reboot
 
-The selection is saved to the roboRIO's flash. If the RIO resets mid-match, robot code
-restarts and **comes back on the same controller you selected**. You do not need to do
-anything.
+**Brownout (voltage sag): nothing to do.** A brownout cuts motor power but does *not*
+restart robot code, so the latched selection is untouched and the robot keeps driving on
+the same controller. This is confirmed in the July practice logs — sessions with 64, 9,
+3, and 1 brownout events all kept running with no code restart.
 
-`DRIVING NOW` will name the restored controller rather than reading
-`-- NOT ENABLED YET --`, so you can confirm the recovery took.
+**Code restart, RIO reboot, or redeploy: the selection is lost.** It is not saved
+anywhere. Robot code comes back on `FLIGHTSTICK Drive (normal)`, the default. If an Xbox
+driver is up, re-pick `XBOX CONTROLLER Drive` from the dropdown before enabling.
 
-This also survives a full power cycle and a code redeploy.
-
-> **The selection is sticky across events.** It stays wherever it was last set — including
-> days later at the next event. If you finished the last event on Xbox, the robot boots on
-> Xbox. Always confirm `DRIVE NEXT ENABLE` before your first match.
+> **Confirm the dropdown before your first match, and after any redeploy between
+> matches.** There is no stored selection to fall back on — unlike earlier versions of
+> this code, the choice is not sticky across restarts or across events.
 
 ---
 
@@ -237,11 +240,12 @@ Check rotation direction the same way with the right stick.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Dropdown change does nothing to `DRIVE NEXT ENABLE` | Dashboard not connected | Reconnect Elastic; check team number |
-| `DRIVING NOW` disagrees with `DRIVE NEXT ENABLE` | Selection made but not yet latched | Disable, re-enable |
+| Dropdown will not change / snaps back | Dashboard not connected | Reconnect Elastic; check team number |
+| Changed the dropdown mid-match, nothing happened | Selection latches only at enable | Disable, re-enable |
 | Controller does nothing at all | Wrong DS port | Check DS USB tab: Xbox on 1, flightstick on 2 |
 | Robot drives backwards in Xbox mode | Stick sign convention | See section 7 |
-| Robot boots on the wrong controller | Sticky saved selection | Re-pick from the dropdown |
+| Robot boots on the flightstick | Selection is not saved across restarts | Re-pick from the dropdown before enabling |
+| `driveController` disagrees with the dropdown | Selection made but not yet latched | Disable, re-enable |
 | Widgets missing in Elastic | Robot code not running | Confirm code is deployed and running |
 
 ---
@@ -250,8 +254,12 @@ Check rotation direction the same way with the right stick.
 
 | File | Role |
 |---|---|
-| `HardwareConstants.ControllerConstants` | `XBOX_DRIVE_MODE` flag, dashboard keys, display names |
+| `HardwareConstants.ControllerConstants` | `XBOX_DRIVE_MODE` flag, chooser key, option labels |
 | `Triggers.java` | `sourced()` routing, `driveXSupplier`/`driveYSupplier`/`driveRotSupplier` |
-| `RobotContainer.java` | Chooser setup, `isXboxDriveSelected()`, `persistDriveControllerSelection()` |
+| `RobotContainer.java` | `driveControllerChooser` setup, `isXboxDriveSelected()` |
 | `Robot.teleopInit()` | The latch — the only place the selection is read |
-| `Robot.disabledPeriodic()` | Updates `DRIVE NEXT ENABLE`, saves selection to flash |
+| `Robot.robotPeriodic()` | Logs `driveController`, the latched value |
+
+The chooser is a `LoggedDashboardChooser<Boolean>`, the same type and wiring as the
+`Driver Preset` chooser: options declared in the `RobotContainer` constructor, read once
+through a one-line accessor, latched in `teleopInit`, logged once in `robotPeriodic`.

--- a/docs/drive-controller-mode.md
+++ b/docs/drive-controller-mode.md
@@ -112,7 +112,7 @@ driver is up, re-pick `XBOX CONTROLLER Drive` from the dropdown before enabling.
 | Left trigger | Intake roller |
 | Left bumper | Intake in (pivot up) |
 | Right bumper | Intake out (pivot down) |
-| Right stick press | Trench align |
+| X | Trench align |
 | A | Bump align |
 | Y | Shoot from tower |
 
@@ -143,8 +143,8 @@ These stay on the flightstick and have no Xbox button:
 - **Manual compress** — auto-compress on shoot still works.
 - **Demo / tuning / hardstop shots** — practice and demo only.
 
-If any of these turn out to matter in a real match, Xbox X, the D-pad, Start, Back, and
-the left stick press are all still free.
+If any of these turn out to matter in a real match, the D-pad, Start, Back, and both
+stick presses are all still free.
 
 ---
 
@@ -168,8 +168,9 @@ public Trigger shootFromTowerButton() {
 ```
 
 The **first** argument is the binding when the flightstick drives; the **second** is
-the binding in Xbox drive mode. To move this onto Xbox X, change `controller.y()` to
-`controller.x()` (and fix the `// Y in Xbox mode` comment).
+the binding in Xbox drive mode. To move this onto Xbox Back, change `controller.y()` to
+`controller.back()` (and fix the `// Y in Xbox mode` comment). Pick from the free list
+below — X is trench align, so reusing it would put two live functions on one button.
 
 **2. Override functions** (`allianceWinFlipper`, `allianceWinDisabler`) also use
 `sourced(...)`, but the arguments read the opposite way — these live on the
@@ -206,8 +207,8 @@ hidden toggle on the pad, and double compress is not available in that mode.
 | Start / Back | `controller.start()` / `.back()` |
 | Flightstick button N | `thrustmaster.button(N)` |
 
-**Free Xbox buttons** — nothing on them in Xbox drive mode: X, the D-pad, Start, Back,
-and the left stick press. Prefer these when adding a function.
+**Free Xbox buttons** — nothing on them in Xbox drive mode: the D-pad, Start, Back, and
+both stick presses. Prefer these when adding a function.
 
 ### Rules
 

--- a/src/main/java/frc/robot/HardwareConstants.java
+++ b/src/main/java/frc/robot/HardwareConstants.java
@@ -227,18 +227,6 @@ public class HardwareConstants {
     // per loop would cost real loop time.
     public static boolean XBOX_DRIVE_MODE = false;
 
-    // ---- Display names ----
-    // Every readout names the physical controller outright. A driver who has never seen this
-    // dashboard should be able to read one line and know which device to pick up, without
-    // interpreting a checkbox or knowing which mode is "default".
-    public static final String XBOX_LABEL = "XBOX CONTROLLER";
-    public static final String FLIGHTSTICK_LABEL = "FLIGHTSTICK";
-
-    /** Human-readable name of the drive controller for a given mode flag. */
-    public static String driveControllerLabel(boolean xboxDrive) {
-      return xboxDrive ? XBOX_LABEL : FLIGHTSTICK_LABEL;
-    }
-
     // ---- Selector ----
     // A named dropdown, not a boolean toggle. A toggle labelled "Use Xbox Drive" tells a new
     // driver what ON means but never what OFF means; a two-option chooser spells out both
@@ -246,41 +234,6 @@ public class HardwareConstants {
     public static final String driveControllerChooserKey = "DRIVE CONTROLLER";
     public static final String FLIGHTSTICK_OPTION = "FLIGHTSTICK Drive (normal)";
     public static final String XBOX_OPTION = "XBOX CONTROLLER Drive";
-
-    /** Chooser option label for a given mode flag. */
-    public static String driveControllerOption(boolean xboxDrive) {
-      return xboxDrive ? XBOX_OPTION : FLIGHTSTICK_OPTION;
-    }
-
-    // Persistent storage key for the selection. Preferences writes through to
-    // /home/lvuser/networktables.json on the roboRIO's flash, so the selection survives a
-    // brownout-induced RIO reset, a code restart, and a redeploy. Without this, a mid-match
-    // reset would bring the robot back on the flightstick regardless of who is driving.
-    //
-    // NOTE: this makes the selection STICKY across events, not just matches. It stays where
-    // it was last set until someone changes it, including across a power cycle days later.
-    // It is cleared by reimaging the RIO or deleting networktables.json.
-    public static final String driveControllerPrefKey = "DriveController_UseXbox";
-
-    // ---- Status readouts ----
-    // What is actually driving the robot RIGHT NOW (the latched value). Updated only at
-    // teleopInit, so during a match this always reflects the scheme the robot is really
-    // running -- not wherever the selector happens to be sitting.
-    public static final String driveControllerActiveKey = "DRIVING NOW";
-
-    // What WILL drive the robot at the next enable (the pending selection). Updated while
-    // disabled so the drive team can change the selection and immediately confirm it took,
-    // instead of finding out when the match starts.
-    //
-    // These are separate on purpose. If a single key tracked the selector live, it would show
-    // the new controller the instant someone changed it even though the robot was still
-    // running the old scheme -- which is exactly how a match gets driven with the wrong
-    // stick. Put both on the Elastic teleop tab; they agree except between a selection change
-    // and the next enable.
-    public static final String driveControllerPendingKey = "DRIVE NEXT ENABLE";
-
-    // Shown before the first enable of a power cycle, when nothing has been latched yet.
-    public static final String NOT_YET_LATCHED = "-- NOT ENABLED YET --";
   }
 
   public static class Zones {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -162,6 +162,7 @@ public class Robot extends LoggedRobot {
     }
 
     Logger.recordOutput("driverPreset", DriveConstants.rotationExponent);
+    Logger.recordOutput("driveController", HardwareConstants.ControllerConstants.XBOX_DRIVE_MODE);
   }
 
   /** This function is called once when the robot is disabled. */
@@ -175,19 +176,6 @@ public class Robot extends LoggedRobot {
     // This lets the drive team verify the selected auto path and robot placement.
     robotContainer.updateAutoPreview();
     robotContainer.checkStartPose();
-
-    // Show which controller will drive at the next enable, so changing the selector gives
-    // immediate visible confirmation instead of a surprise when the match starts.
-    // Safe to read the chooser here — we are disabled, so this is not on the match loop.
-    SmartDashboard.putString(
-        HardwareConstants.ControllerConstants.driveControllerPendingKey,
-        HardwareConstants.ControllerConstants.driveControllerLabel(
-            robotContainer.isXboxDriveSelected()));
-
-    // Save the selection to flash as soon as it is made, rather than waiting for the enable.
-    // If the RIO resets before the match even starts, we still come back on the right stick.
-    // No-ops unless the value actually changed.
-    robotContainer.persistDriveControllerSelection();
   }
 
   /** This autonomous runs the autonomous command selected by your {@link RobotContainer} class. */
@@ -228,24 +216,6 @@ public class Robot extends LoggedRobot {
     // disable -> enable. Reading it here instead of per-loop keeps NetworkTables traffic
     // out of the 20 ms loop entirely.
     HardwareConstants.ControllerConstants.XBOX_DRIVE_MODE = robotContainer.isXboxDriveSelected();
-
-    // Persist the latched value too, in case the selection was made while already enabled
-    // (practice, or a re-enable after a fault) and disabledPeriodic never saw it.
-    robotContainer.persistDriveControllerSelection();
-
-    // Name the controller that is actually driving now, so the drive team reads
-    // "DRIVING NOW: XBOX CONTROLLER" rather than interpreting a switch. Both the live and
-    // pending keys are written here so they agree the moment the latch takes.
-    String driveLabel =
-        HardwareConstants.ControllerConstants.driveControllerLabel(
-            HardwareConstants.ControllerConstants.XBOX_DRIVE_MODE);
-    SmartDashboard.putString(
-        HardwareConstants.ControllerConstants.driveControllerActiveKey, driveLabel);
-    SmartDashboard.putString(
-        HardwareConstants.ControllerConstants.driveControllerPendingKey, driveLabel);
-    Logger.recordOutput("DriveMode/DriveController", driveLabel);
-    Logger.recordOutput(
-        "DriveMode/XboxDrive", HardwareConstants.ControllerConstants.XBOX_DRIVE_MODE);
 
     CommandScheduler.getInstance().schedule(robotContainer.getIntakeRollerCommand());
     CommandScheduler.getInstance().schedule(robotContainer.getIntakePivotCommand());

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -20,9 +20,7 @@ import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.units.measure.Distance;
-import edu.wpi.first.wpilibj.Preferences;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
-import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
@@ -109,7 +107,7 @@ public class RobotContainer {
 
   // Which controller drives the robot. Read only at teleopInit — see
   // HardwareConstants.ControllerConstants.XBOX_DRIVE_MODE for the latching rationale.
-  private final SendableChooser<Boolean> driveControllerChooser = new SendableChooser<>();
+  private final LoggedDashboardChooser<Boolean> driveControllerChooser;
 
   // ── Auto Preview & Starting Pose Check ──────────────────────────────────────
   // Field2d widget to show the selected auto's path and the robot's current position.
@@ -258,48 +256,16 @@ public class RobotContainer {
     driverPresetChooser.addDefaultOption("Parker", 1.35); // 1.35
     driverPresetChooser.addOption("Christian", 2.0); // 2.0
 
+    driveControllerChooser =
+        new LoggedDashboardChooser<Boolean>(
+            HardwareConstants.ControllerConstants.driveControllerChooserKey);
+    driveControllerChooser.addDefaultOption(
+        HardwareConstants.ControllerConstants.FLIGHTSTICK_OPTION, false);
+    driveControllerChooser.addOption(HardwareConstants.ControllerConstants.XBOX_OPTION, true);
+
     // Publish the auto preview field to the dashboard so we can see the selected path
     SmartDashboard.putData("Auto Preview", autoPreviewField);
     SmartDashboard.putNumber(autoDelayKey, defaultAutoDelay);
-
-    // ── Drive-controller selector ───────────────────────────────────────────────
-    // Recover the last selection from the roboRIO's persistent Preferences file. This is
-    // what makes a mid-match brownout survivable: if the RIO resets, robot code restarts
-    // with NetworkTables empty, and without this the chooser would come back on the
-    // flightstick and hand an Xbox driver a dead controller for the rest of the match.
-    // Preferences is backed by /home/lvuser/networktables.json on flash, so it survives a
-    // code restart, a RIO reboot, and a redeploy.
-    Preferences.initBoolean(HardwareConstants.ControllerConstants.driveControllerPrefKey, false);
-    boolean restoredXboxDrive =
-        Preferences.getBoolean(HardwareConstants.ControllerConstants.driveControllerPrefKey, false);
-
-    // Apply the restored selection immediately, not just at the next teleopInit, so the
-    // correct scheme is live the instant code finishes starting.
-    HardwareConstants.ControllerConstants.XBOX_DRIVE_MODE = restoredXboxDrive;
-
-    // Both options are spelled out by name so a driver picks "XBOX CONTROLLER Drive" rather
-    // than deducing it from a switch position. The restored selection becomes the chooser's
-    // default, so getSelected() returns it before anyone touches the dashboard.
-    driveControllerChooser.setDefaultOption(
-        HardwareConstants.ControllerConstants.driveControllerOption(restoredXboxDrive),
-        restoredXboxDrive);
-    driveControllerChooser.addOption(
-        HardwareConstants.ControllerConstants.driveControllerOption(!restoredXboxDrive),
-        !restoredXboxDrive);
-    SmartDashboard.putData(
-        HardwareConstants.ControllerConstants.driveControllerChooserKey, driveControllerChooser);
-
-    // Name the restored controller rather than "-- NOT ENABLED YET --" when we actually did
-    // recover a selection: after a mid-match reset the drive team needs to see immediately
-    // that the robot came back on the right stick.
-    SmartDashboard.putString(
-        HardwareConstants.ControllerConstants.driveControllerActiveKey,
-        restoredXboxDrive
-            ? HardwareConstants.ControllerConstants.driveControllerLabel(true)
-            : HardwareConstants.ControllerConstants.NOT_YET_LATCHED);
-    SmartDashboard.putString(
-        HardwareConstants.ControllerConstants.driveControllerPendingKey,
-        HardwareConstants.ControllerConstants.driveControllerLabel(isXboxDriveSelected()));
 
     // autoChooser.addOption(
     //     "Drive Wheel Radius Characterization", DriveCommands.wheelRadiusCharacterization(drive));
@@ -342,28 +308,9 @@ public class RobotContainer {
     return Triggers.getInstance().driveRotSupplier(); // twist / right stick X
   }
 
-  /**
-   * Currently selected drive controller. Falls back to the value restored from Preferences at
-   * construction if the chooser has no selection yet.
-   */
+  /** Currently selected drive controller. Latched into XBOX_DRIVE_MODE at teleopInit. */
   public boolean isXboxDriveSelected() {
-    Boolean selected = driveControllerChooser.getSelected();
-    return selected != null ? selected : HardwareConstants.ControllerConstants.XBOX_DRIVE_MODE;
-  }
-
-  /**
-   * Writes the drive-controller selection to the roboRIO's persistent Preferences so it survives a
-   * brownout reset. Only writes when the value actually changed — Preferences writes hit flash, and
-   * rewriting an unchanged value every loop would be pointless wear.
-   */
-  public void persistDriveControllerSelection() {
-    boolean selected = isXboxDriveSelected();
-    if (selected
-        != Preferences.getBoolean(
-            HardwareConstants.ControllerConstants.driveControllerPrefKey, false)) {
-      Preferences.setBoolean(
-          HardwareConstants.ControllerConstants.driveControllerPrefKey, selected);
-    }
+    return driveControllerChooser.get();
   }
 
   // NamedCommands

--- a/src/main/java/frc/robot/Triggers.java
+++ b/src/main/java/frc/robot/Triggers.java
@@ -88,8 +88,8 @@ public class Triggers {
   }
 
   public Trigger trenchAlignButton() {
-    // R3 in Xbox mode
-    return sourced(thrustmaster.button(2), controller.rightStick());
+    // X in Xbox mode
+    return sourced(thrustmaster.button(2), controller.x());
   }
 
   public Trigger intakeInButton() {


### PR DESCRIPTION
Two separate changes, one commit each so the binding move can be reverted on its own at
an event.

## 1. Chooser matches the Driver Preset architecture (`7d587dd`)

The Xbox drive selector had grown its own shape: a raw `SendableChooser`, flash
persistence via `Preferences`, two mirrored dashboard readouts, label helpers, and a
`disabledPeriodic` block doing two NT reads and a string write every loop. The
`Driver Preset` chooser next to it does the same job in five lines.

Now a `LoggedDashboardChooser<Boolean>`: options declared in the `RobotContainer`
constructor, a one-line accessor, the existing latch in `teleopInit`, one
`recordOutput` in `robotPeriodic`. Net −146/+16 lines of code.

**Removed:** `Preferences` persistence and `persistDriveControllerSelection()`; the
`DRIVING NOW` / `DRIVE NEXT ENABLE` readouts and `NOT_YET_LATCHED`;
`driveControllerLabel()`, `driveControllerOption()`, `XBOX_LABEL`, `FLIGHTSTICK_LABEL`;
the `disabledPeriodic` block; two now-unused imports.

**Kept:** `XBOX_DRIVE_MODE` and its latching rationale — `Triggers.java:53` reads it
every loop, which is why it is latched rather than polled. The chooser still publishes
to `/SmartDashboard/DRIVE CONTROLLER`, so saved Elastic layouts keep working.

### Behavioral changes to review

- **Before the first teleop enable of a power cycle, `XBOX_DRIVE_MODE` is `false`
  (flightstick).** It previously seeded from flash in the constructor. This matches
  `Driver Preset`, whose `rotationExponent` is likewise unset until `teleopInit`, and
  `false` is the documented default.
- **The selection no longer survives a code restart, RIO reboot, or redeploy.**
  Confirmed with @rjfortyfive that this is acceptable. Worth knowing *why* it is safe:
  a brownout does not restart robot code, so brownouts never lost the selection in the
  first place. The July logs bear this out — sessions with 64, 9, 3 and 1 brownout
  events all kept running with no restart.
- **The drive team loses the large `DRIVING NOW` text readout.** The doc now points at
  the `driveController` boolean output as the replacement. If a named string readout
  turns out to matter at an event, it is a one-line change to the existing
  `recordOutput` in `robotPeriodic`.

## 2. Trench align moved to Xbox X (`fa8185f`)

Was R3 — a press of the same stick used for rotation, so committing the press can nudge
heading right as the align starts. X puts it on the face-button cluster with the other
two aligns (A bump align, Y shoot from tower) and frees both stick presses.

X was previously referenced only by `xWheels()` and `simShootFromTowerButton()`, both
wired in `configureSimBindings()` and not on the real robot, so nothing else claims it
in Xbox drive mode. Flightstick drive mode is untouched — trench align stays on
thrustmaster button 2.

## Docs

`docs/drive-controller-mode.md` updated for both: Elastic setup, the switching
procedure, brownout/reboot behavior, troubleshooting, the code map, the section 5 button
map, and the free-button lists. The section 6 worked example previously told the reader
to move a binding onto X, which would now document a double-binding — retargeted to
Back.

## Verification

`./gradlew build` (compile + spotless) passes on the final state; the one warning is
pre-existing (`Drive.java:291`). **Not yet run on the robot** — the binding change and
the first-enable default both want a quick check before a match:

- [ ] Enable in Xbox drive mode, confirm X triggers trench align
- [ ] Confirm R3 now does nothing
- [ ] Confirm the robot comes up on the flightstick after a fresh deploy
- [ ] Confirm the `DRIVE CONTROLLER` dropdown still appears in the saved Elastic layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dashboard control for selecting Xbox or flightstick driving mode.
  * The selected mode takes effect when the robot is next enabled.
  * The currently active mode is now reported in telemetry.

* **Bug Fixes**
  * Updated Xbox controls so trench alignment uses the X button.
  * Clarified controller behavior after brownouts, reboots, redeploys, and code restarts.

* **Documentation**
  * Updated setup, button mappings, troubleshooting, and controller-selection guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->