### PR TITLE
Hold auto hub shot until the drivetrain is aimed, like teleop does

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -332,6 +332,12 @@ public class RobotContainer {
             intakeRoller, HardwareConstants.CompConstants.Voltages.intakeRollerVoltage));
 
     // Auto shoot command
+    //
+    // The alignment condition passed to autoShootToHub is the hub-loose check — the same
+    // tolerance teleop's isAlignedLooser uses for a hub shot, and measured against the same
+    // getAngleToAllianceHub() heading the paired joystickDriveAtAngle is driving to. It is read
+    // as a plain BooleanSupplier inside waitUntil, so nothing new is bound to the scheduler and
+    // the auto group's requirements are unchanged.
     NamedCommands.registerCommand(
         "Shoot",
         DriveCommands.joystickDriveAtAngle(
@@ -345,7 +351,8 @@ public class RobotContainer {
                     lowerFeeder,
                     transport,
                     intakeRoller,
-                    intakePivot)));
+                    intakePivot,
+                    () -> RobotState.getInstance().isAlignedToHubLoose())));
 
     // Stop all subsystems after shooting
     NamedCommands.registerCommand(

--- a/src/main/java/frc/robot/commands/ShootSequences.java
+++ b/src/main/java/frc/robot/commands/ShootSequences.java
@@ -12,10 +12,24 @@ import frc.robot.subsystems.lowerFeeder.LowerFeeder;
 import frc.robot.subsystems.prestage.Prestage;
 import frc.robot.subsystems.transport.Transport;
 import frc.robot.subsystems.upperFeeder.UpperFeeder;
+import java.util.function.BooleanSupplier;
 import org.littletonrobotics.junction.Logger;
 
 public class ShootSequences {
 
+  /**
+   * Auto hub shot: spin up the flywheel/hood/prestage immediately, then feed once the shooter is
+   * ready AND the drivetrain is pointed at the hub.
+   *
+   * <p>Mirrors the teleop gating, where the feeders, agitator, and compress are all held off until
+   * {@code isAlignedLooser} is true. Uses the standard Spinup → Align → Act budget: phase 1 waits
+   * for spin-up, phase 2 waits for alignment with the remainder of {@code alignmentTimeoutSeconds},
+   * so feeding always begins within that total budget even if alignment never arrives.
+   *
+   * @param isAligned true when the drivetrain is pointed at the hub within tolerance. Supplied by
+   *     the caller so the alignment target always matches whatever the paired drive command is
+   *     aiming at.
+   */
   public static Command autoShootToHub(
       Flywheel flywheel,
       Prestage prestage,
@@ -24,7 +38,8 @@ public class ShootSequences {
       LowerFeeder lowerFeeder,
       Transport transport,
       intakeRoller intakeRoller,
-      IntakePivot intakePivot) {
+      IntakePivot intakePivot,
+      BooleanSupplier isAligned) {
     return Commands.parallel(
             Commands.runOnce(() -> Logger.recordOutput("RobotState/shooting", true)),
             Commands.parallel(
@@ -35,6 +50,17 @@ public class ShootSequences {
             Commands.sequence(
                 Commands.waitUntil(flywheel.isFlywheelSpunUp)
                     .withTimeout(HardwareConstants.CompConstants.Waits.spinUpTimeOut),
+                // Hold the feed until we're aimed. Timeout is the remaining alignment budget, so
+                // a shot that never lines up still fires rather than stalling the auto.
+                Commands.waitUntil(isAligned)
+                    .withTimeout(
+                        HardwareConstants.CompConstants.Waits.alignmentTimeoutSeconds
+                            - HardwareConstants.CompConstants.Waits.spinUpTimeOut),
+                // Records whether we actually got aligned or fell through on the timeout.
+                Commands.runOnce(
+                    () ->
+                        Logger.recordOutput(
+                            "RobotState/autoShotAlignedAtFeed", isAligned.getAsBoolean())),
                 Commands.parallel(
                     FeederCommands.setLowerFeederVelocity(
                         lowerFeeder, HardwareConstants.CompConstants.Velocities.feederVelocity),


### PR DESCRIPTION
## What changed

The auto `Shoot` named command fed as soon as the flywheel reported spun up — it never looked at heading. Any residual rotation error left at the end of a path got thrown away as missed fuel. Teleop never does this: the feeders, agitator, and auto-compress are all gated on `isAlignedLooser` before anything moves.

`ShootSequences.autoShootToHub` now inserts the alignment phase of the repo's documented Spinup → Align → Act pattern (`.claude/rules/03-commands.md`) between the spin-up wait and the feed:

```
waitUntil(isFlywheelSpunUp).withTimeout(spinUpTimeOut)          // 0.5 s, phase 1
waitUntil(isAligned).withTimeout(alignmentTimeout - spinUpTimeOut)  // 1.0 s, phase 2
parallel(feeders, transport, agitate, compress)                 // phase 3
```

Both timeout constants are existing values in `HardwareConstants.CompConstants.Waits`; nothing was retuned. Phase 2's budget is the remainder of `alignmentTimeoutSeconds` (1.5 s total), which is the same failsafe budget the teleop `...AfterWait` factories in `FeederCommands` / `TransportCommands` / `intakeRollerCommands` already use.

The alignment condition is a caller-supplied `BooleanSupplier` rather than a read of the `Triggers` singleton. `RobotContainer` passes `RobotState.getInstance()::isAlignedToHubLoose` — the same 7° `hubLooseAlignmentToleranceDegrees` teleop uses for a hub shot, measured against the same `getAngleToAllianceHub()` heading the paired `joystickDriveAtAngle` is driving to, so the gate can't disagree with what the drivetrain is actually aiming at.

Also added `RobotState/autoShotAlignedAtFeed`, logged at the instant feeding starts, so a match log shows whether each auto shot fired aligned or fell through on the timeout.

## Behavioral consequence

**Feeding in auto is now delayed until the robot is aimed, up to 1.0 s longer than before.** Worst case (never aligns) the feed starts 1.5 s into the shot instead of 0.5 s. Every `Shoot` in every auto is raced against a `wait` in the `.auto` file, and the tightest is 2.6 s (`Qual55`), so the worst case still leaves ≥ 1.1 s of feed time — down from ≥ 2.1 s. Typical case should be *faster* than the timeout suggests: phase 1 exits early on spin-up and phase 2 exits early on alignment, and the paths already end roughly pointed at the hub.

**Failure mode if wrong:** if the pose estimate is bad enough that `isAlignedToHubLoose()` never returns true, every auto shot pays the full 1.5 s and fires anyway — fewer balls per shot window, but the auto never stalls and never loses a shot entirely. Check `RobotState/autoShotAlignedAtFeed` in the log; if it's `false`, that's what happened.

## Command-scheduling safety

This was the main risk in the request, so explicitly:

- **No new requirements.** A `SequentialCommandGroup`'s requirement set is the union of all sub-commands, computed at construction and held from schedule to end. `waitUntil` and `runOnce(Runnable)` (no subsystem arg) declare none, so the `Shoot` group requires exactly the same subsystems, for exactly the same span, as before. Nothing new can conflict with the PathPlanner path-following command.
- **No new triggers or scheduled commands.** `isAligned` is polled as a plain `BooleanSupplier` inside `waitUntil`. Nothing is bound to the button loop, so there's no path by which this interrupts the auto group.
- **Deliberately not `Triggers.isAlignedForCurrentShot`.** That one is `.debounce(0.3, kRising)`, and a debounced trigger polled both by the scheduler's button loop *and* from inside a command gets evaluated twice per loop. `isAlignedToHubLoose()` is stateless, so extra polls are free and idempotent.
- **Gate is on the start of feeding only**, matching the request. Teleop additionally *stops* feeding if alignment is lost mid-burst (its `whileTrue` trigger has `.and(isAlignedLooser)`); replicating that in auto would risk stuttering the feed inside an already-tight window. Happy to add it if you want the behaviors identical.
- `NamedCommands.registerCommand` / `AutoBuilder.buildAutoChooser()` ordering is untouched. No `.auto` file was modified.

## Verification

`ShootSequences.java` and `RobotContainer.java` both parse and are google-java-format clean (verified against GJF directly).

**`./gradlew compileJava` and `spotlessCheck` could not be run in this session** and this has not been compiled — flagging that rather than implying it was verified:

- The vendor deps (WPILib, AdvantageKit, Phoenix6, PathPlanner, PhotonVision) can't be fetched — this environment's network policy returns 403 for `frcmaven.wpi.edu` and `maven.ctr-electronics.com`, and they aren't in the Gradle cache.
- `spotlessJava` fails independently on `NoSuchMethodError: JCTree$JCImport.getQualifiedIdentifier()` — spotless 6.12.0's bundled google-java-format predates JDK 21's javac API change, and only JDK 21 is installed here. That's pre-existing and reproduces on unmodified `main`.

Please run `./gradlew build` locally before deploying. The API surface touched is small: `RobotState.isAlignedToHubLoose()` (public, `RobotState.java:359`), `Commands.waitUntil(BooleanSupplier)`, and `Logger.recordOutput(String, boolean)`. `autoShootToHub` has exactly one caller, updated in the same commit.

Sim check worth doing before the field: run an auto and confirm in AdvantageScope that `RobotState/isAlignedToHubLoose` goes true before the feeder velocities step up, and that the `Shoot` command still runs to the race timeout rather than being interrupted early.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Epn1XqHajpvTtL4gwDpUFB)_