### PR TITLE
Exclude trench tags from the vision pose solve, and log what multi-tag actually used

### DIFF
--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -16,6 +16,7 @@ import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation3d;
+import java.util.Set;
 import org.littletonrobotics.junction.Logger;
 
 public class VisionConstants {
@@ -78,6 +79,25 @@ public class VisionConstants {
           new Translation3d(
               Inches.of(-12.572), Inches.of(5.375), Inches.of(12.509)), // -11.028 - 1.5
           new Rotation3d(Degrees.of(0.0), Degrees.of(-15.0), Degrees.of(180)));
+
+  // ---- Trench tags ----
+
+  // Tags mounted inside the trench. They are only ever seen through the trench opening
+  // at a steep, glancing angle, which produces unreliable PnP solves, so they must not
+  // contribute to a pose estimate at all.
+  //
+  // Held as a static Set so the trench check costs a hash lookup instead of rebuilding
+  // an 8-element set per camera per frame inside the vision loop.
+  private static final Set<Integer> trenchTagIds = Set.of(1, 6, 7, 12, 17, 22, 23, 28);
+
+  /**
+   * Returns whether a fiducial ID belongs to a trench tag.
+   *
+   * @param fiducialId The AprilTag fiducial ID to test.
+   */
+  public static boolean isTrenchTag(int fiducialId) {
+    return trenchTagIds.contains(fiducialId);
+  }
 
   // ---- Filtering thresholds ----
 

--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -99,6 +99,22 @@ public class VisionConstants {
     return trenchTagIds.contains(fiducialId);
   }
 
+  // How many NON-trench tags must have contributed to a coprocessor multi-tag solve for that
+  // solve to be kept when a trench tag was also folded into it.
+  //
+  // Multi-tag PnP runs on the coprocessor and arrives as one baked transform, so a trench tag
+  // inside it cannot be removed here — only tolerated or the whole solve rejected. Multi-tag is
+  // a least-squares fit: with two or more clean tags it is over-constrained and one bad tag
+  // shifts the result rather than flipping it. With only one clean tag the trench tag carries
+  // real weight, and the clean single-tag fallback is the better answer.
+  //
+  //   2                 — tolerate a trench tag when >=2 clean tags also contributed (lenient)
+  //   Integer.MAX_VALUE — reject any multi-tag solve that used a trench tag at all (strict)
+  //
+  // Log /Vision/CameraN/MultiTagFiducialIdsUsed and .../MultiTagSolvesDiscarded to see how often
+  // this actually fires before changing it.
+  public static int minCleanTagsToKeepMultiTag = 2;
+
   // ---- Filtering thresholds ----
 
   // Single-tag ambiguity above this is rejected (multi-tag is always trusted).

--- a/src/main/java/frc/robot/subsystems/vision/io/VisionIO.java
+++ b/src/main/java/frc/robot/subsystems/vision/io/VisionIO.java
@@ -19,6 +19,16 @@ public interface VisionIO {
         new TargetObservation(Rotation2d.kZero, Rotation2d.kZero);
     public PoseObservation[] poseObservations = new PoseObservation[0];
     public int[] tagIds = new int[0];
+
+    // Fiducial IDs the coprocessor's multi-tag PnP solved from this cycle, recorded BEFORE the
+    // trench filter runs. tagIds shows what was visible and survived filtering; this shows what
+    // the multi-tag solve was actually built from, which is the only way to tell how often a
+    // trench tag lands inside one.
+    public int[] multiTagFiducialIdsUsed = new int[0];
+
+    // Multi-tag solves dropped this cycle because too few non-trench tags contributed. Measures
+    // what VisionConstants.minCleanTagsToKeepMultiTag is costing in accepted multi-tag poses.
+    public int multiTagSolvesDiscarded = 0;
   }
 
   /** Represents the angle to a simple target, not used for pose estimation. */

--- a/src/main/java/frc/robot/subsystems/vision/io/VisionIOPhotonVision.java
+++ b/src/main/java/frc/robot/subsystems/vision/io/VisionIOPhotonVision.java
@@ -77,6 +77,29 @@ public class VisionIOPhotonVision implements VisionIO {
         continue;
       }
 
+      // --- Trench tag exclusion ---
+      // Trench tags must not contribute to a pose estimate. This has to happen BEFORE the
+      // estimator runs, because both strategies solve from the result we hand them.
+      //
+      // The two strategies need different treatment:
+      //   - Single-tag fallback solves from result.targets, so dropping trench targets from
+      //     that list is enough — the estimator then picks the best remaining tag.
+      //   - Multi-tag PnP was already solved on the coprocessor, and estimateCoprocMultiTagPose()
+      //     just reads that baked transform. Removing targets client-side cannot change it, so
+      //     if the coprocessor folded a trench tag into the solve the only correct move is to
+      //     discard the whole multi-tag result and let the single-tag fallback handle the frame.
+      if (result.getMultiTagResult().isPresent()
+          && result.getMultiTagResult().get().fiducialIDsUsed.stream()
+              .anyMatch(id -> isTrenchTag(id))) {
+        result.multitagResult = Optional.empty();
+      }
+      result.targets.removeIf(target -> isTrenchTag(target.fiducialId));
+
+      // Every target in the frame was a trench tag — nothing left to estimate from
+      if (!result.hasTargets()) {
+        continue;
+      }
+
       // --- Pose estimation using PhotonPoseEstimator ---
       // Strategy: try multi-tag first (more accurate), fall back to lowest-ambiguity single-tag.
       // estimateCoprocMultiTagPose() uses the coprocessor's multi-tag PnP solve when available.
@@ -94,19 +117,10 @@ public class VisionIOPhotonVision implements VisionIO {
 
       EstimatedRobotPose estimate = estimatedPose.get();
 
-      HashSet<Integer> trenchIDs = new HashSet<Integer>();
-      trenchIDs.add(1);
-      trenchIDs.add(6);
-      trenchIDs.add(7);
-      trenchIDs.add(12);
-      trenchIDs.add(17);
-      trenchIDs.add(22);
-      trenchIDs.add(23);
-      trenchIDs.add(28);
-
-      // Collect all tag IDs seen (estimate.targetsUsed contains every target in the frame)
+      // Collect all tag IDs seen. estimate.targetsUsed is the filtered target list from
+      // above, so trench tags are already gone.
       for (var target : estimate.targetsUsed) {
-        if (target.fiducialId >= 0 && !trenchIDs.contains(target.fiducialId)) {
+        if (target.fiducialId >= 0) {
           tagIds.add((short) target.fiducialId);
         }
       }

--- a/src/main/java/frc/robot/subsystems/vision/io/VisionIOPhotonVision.java
+++ b/src/main/java/frc/robot/subsystems/vision/io/VisionIOPhotonVision.java
@@ -60,6 +60,8 @@ public class VisionIOPhotonVision implements VisionIO {
 
     // Read new camera observations
     Set<Short> tagIds = new HashSet<>();
+    Set<Short> multiTagIdsUsed = new HashSet<>();
+    int multiTagSolvesDiscarded = 0;
     List<PoseObservation> poseObservations = new LinkedList<>();
     for (var result : camera.getAllUnreadResults()) {
       // Update latest target observation (used for simple target-tracking, not pose estimation)
@@ -85,13 +87,20 @@ public class VisionIOPhotonVision implements VisionIO {
       //   - Single-tag fallback solves from result.targets, so dropping trench targets from
       //     that list is enough — the estimator then picks the best remaining tag.
       //   - Multi-tag PnP was already solved on the coprocessor, and estimateCoprocMultiTagPose()
-      //     just reads that baked transform. Removing targets client-side cannot change it, so
-      //     if the coprocessor folded a trench tag into the solve the only correct move is to
-      //     discard the whole multi-tag result and let the single-tag fallback handle the frame.
-      if (result.getMultiTagResult().isPresent()
-          && result.getMultiTagResult().get().fiducialIDsUsed.stream()
-              .anyMatch(id -> isTrenchTag(id))) {
-        result.multitagResult = Optional.empty();
+      //     just reads that baked transform. Removing targets client-side cannot change it, so a
+      //     trench tag inside a multi-tag solve can only be tolerated or the solve rejected
+      //     wholesale. VisionConstants.minCleanTagsToKeepMultiTag decides which.
+      if (result.getMultiTagResult().isPresent()) {
+        List<Short> idsUsed = result.getMultiTagResult().get().fiducialIDsUsed;
+        // Recorded before the filter so the log shows what the coprocessor actually solved from
+        for (short id : idsUsed) {
+          multiTagIdsUsed.add(id);
+        }
+        long cleanTags = idsUsed.stream().filter(id -> !isTrenchTag(id)).count();
+        if (cleanTags < minCleanTagsToKeepMultiTag) {
+          result.multitagResult = Optional.empty();
+          multiTagSolvesDiscarded++;
+        }
       }
       result.targets.removeIf(target -> isTrenchTag(target.fiducialId));
 
@@ -181,5 +190,14 @@ public class VisionIOPhotonVision implements VisionIO {
     for (int id : tagIds) {
       inputs.tagIds[i++] = id;
     }
+
+    // Save multi-tag diagnostics. Always assigned, so a cycle with no multi-tag solve reports
+    // empty rather than leaving the previous cycle's values in the log.
+    inputs.multiTagFiducialIdsUsed = new int[multiTagIdsUsed.size()];
+    int j = 0;
+    for (int id : multiTagIdsUsed) {
+      inputs.multiTagFiducialIdsUsed[j++] = id;
+    }
+    inputs.multiTagSolvesDiscarded = multiTagSolvesDiscarded;
   }
 }

--- a/src/test/java/frc/robot/subsystems/vision/TrenchTagFilterTest.java
+++ b/src/test/java/frc/robot/subsystems/vision/TrenchTagFilterTest.java
@@ -1,0 +1,211 @@
+package frc.robot.subsystems.vision;
+
+import static frc.robot.subsystems.vision.VisionConstants.aprilTagLayout;
+import static frc.robot.subsystems.vision.VisionConstants.isTrenchTag;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.geometry.Translation3d;
+import frc.robot.subsystems.vision.io.VisionIO.VisionIOInputs;
+import frc.robot.subsystems.vision.io.VisionIOPhotonVision;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.photonvision.PhotonCamera;
+import org.photonvision.estimation.TargetModel;
+import org.photonvision.simulation.PhotonCameraSim;
+import org.photonvision.simulation.SimCameraProperties;
+import org.photonvision.simulation.VisionSystemSim;
+import org.photonvision.simulation.VisionTargetSim;
+
+/**
+ * Verifies in PhotonVision simulation that trench tags never reach the pose estimator.
+ *
+ * <p>This drives the real production {@link VisionIOPhotonVision#updateInputs} against a simulated
+ * camera looking at real tags from the configured field layout, so it exercises the same code path
+ * the robot runs.
+ *
+ * <p>{@code latestTargetObservation} is computed BEFORE the trench filter runs, so a non-zero
+ * target observation proves the camera genuinely saw the tag. An empty {@code poseObservations}
+ * alongside it proves the filter is what suppressed the solve, rather than the camera having seen
+ * nothing.
+ */
+public class TrenchTagFilterTest {
+  private static VisionSystemSim visionSim;
+  private static PhotonCamera camera;
+  private static VisionIOPhotonVision io;
+
+  // Camera at robot center, level, facing straight forward, at a realistic mounting height.
+  // Height matters: at floor level most tags fall outside the vertical FOV at 2 m standoff.
+  private static final Transform3d ROBOT_TO_CAMERA =
+      new Transform3d(new Translation3d(0.0, 0.0, 0.6), new Rotation3d());
+
+  /** Result of stepping the sim: what the camera saw and what survived the filter. */
+  private record Observed(int poseObservations, Set<Integer> tagIds, boolean sawTarget) {}
+
+  @BeforeAll
+  static void setup() {
+    PhotonCamera.setVersionCheckEnabled(false);
+
+    visionSim = new VisionSystemSim("trenchTagFilterTest");
+    camera = new PhotonCamera("TrenchFilterTestCam");
+    PhotonCameraSim cameraSim =
+        new PhotonCameraSim(camera, new SimCameraProperties(), aprilTagLayout);
+    cameraSim.setMaxSightRange(10.0);
+    visionSim.addCamera(cameraSim, ROBOT_TO_CAMERA);
+
+    io = new VisionIOPhotonVision("TrenchFilterTestCam", ROBOT_TO_CAMERA);
+  }
+
+  @AfterAll
+  static void teardown() {
+    visionSim.clearCameras();
+    camera.close();
+  }
+
+  /** Puts exactly the given tags on the simulated field, using their real layout poses. */
+  private static void setFieldTags(int... tagIds) {
+    visionSim.clearVisionTargets();
+    List<VisionTargetSim> targets = new ArrayList<>();
+    for (int id : tagIds) {
+      targets.add(
+          new VisionTargetSim(
+              aprilTagLayout.getTagPose(id).orElseThrow(), TargetModel.kAprilTag36h11, id));
+    }
+    visionSim.addVisionTargets("apriltag", targets.toArray(new VisionTargetSim[0]));
+  }
+
+  /** A pose 2 m in front of the given tag, facing it. */
+  private static Pose2d poseFacingTag(int tagId) {
+    Pose3d tagPose = aprilTagLayout.getTagPose(tagId).orElseThrow();
+    double tagYaw = tagPose.getRotation().getZ();
+    return new Pose2d(
+        tagPose
+            .getTranslation()
+            .toTranslation2d()
+            .plus(new Translation2d(2.0, new Rotation2d(tagYaw))),
+        new Rotation2d(tagYaw + Math.PI));
+  }
+
+  /**
+   * Steps the sim at the given pose and reports what came through. Warm-up cycles are discarded so
+   * a stale NetworkTables frame from a previous field configuration cannot leak into the
+   * measurement.
+   */
+  private static Observed observe(Pose2d robotPose) {
+    VisionIOInputs inputs = new VisionIOInputs();
+    for (int i = 0; i < 6; i++) {
+      visionSim.update(robotPose);
+      io.updateInputs(inputs);
+    }
+
+    int poseObservations = 0;
+    Set<Integer> tagIds = new LinkedHashSet<>();
+    boolean sawTarget = false;
+    for (int i = 0; i < 6; i++) {
+      visionSim.update(robotPose);
+      io.updateInputs(inputs);
+      poseObservations += inputs.poseObservations.length;
+      for (int id : inputs.tagIds) {
+        tagIds.add(id);
+      }
+      sawTarget |=
+          inputs.latestTargetObservation.tx().getRadians() != 0.0
+              || inputs.latestTargetObservation.ty().getRadians() != 0.0;
+    }
+    return new Observed(poseObservations, tagIds, sawTarget);
+  }
+
+  private static List<Integer> layoutTagIds() {
+    List<Integer> ids = new ArrayList<>();
+    aprilTagLayout.getTags().forEach(tag -> ids.add(tag.ID));
+    return ids;
+  }
+
+  @Test
+  void trenchTagAloneProducesNoPoseObservation() {
+    int checked = 0;
+    for (int tagId : layoutTagIds()) {
+      if (!isTrenchTag(tagId)) {
+        continue;
+      }
+      setFieldTags(tagId);
+      Observed o = observe(poseFacingTag(tagId));
+      checked++;
+
+      System.out.printf(
+          "trench tag %2d alone: sawTarget=%-5s poseObservations=%d tagIds=%s%n",
+          tagId, o.sawTarget(), o.poseObservations(), o.tagIds());
+
+      assertTrue(o.sawTarget(), "camera should still SEE trench tag " + tagId);
+      assertEquals(
+          0, o.poseObservations(), "trench tag " + tagId + " must not produce a pose observation");
+      assertEquals(
+          Set.of(), o.tagIds(), "trench tag " + tagId + " must not appear in reported tag IDs");
+    }
+    assertTrue(checked > 0, "no trench tags found in the configured field layout");
+    System.out.println("PASS: " + checked + " trench tags produced no pose observations");
+  }
+
+  @Test
+  void nonTrenchTagAloneStillProducesPoseObservation() {
+    int produced = 0;
+    int checked = 0;
+    for (int tagId : layoutTagIds()) {
+      if (isTrenchTag(tagId)) {
+        continue;
+      }
+      setFieldTags(tagId);
+      Observed o = observe(poseFacingTag(tagId));
+      checked++;
+      if (o.poseObservations() > 0) {
+        produced++;
+        assertEquals(
+            Set.of(tagId), o.tagIds(), "tag " + tagId + " should be the only reported tag ID");
+      }
+    }
+    System.out.printf("PASS: non-trench tags produced poses for %d/%d tags%n", produced, checked);
+    assertTrue(produced > 0, "no non-trench tag produced a pose — the filter rejects everything");
+  }
+
+  @Test
+  void mixedFrameSolvesFromNonTrenchTagsOnly() {
+    // The realistic case: the full field is present, so a camera pointed at a trench tag also
+    // catches its non-trench neighbours. The solve must survive, sourced only from clean tags.
+    visionSim.clearVisionTargets();
+    visionSim.addAprilTags(aprilTagLayout);
+
+    int mixedFrames = 0;
+    for (int tagId : layoutTagIds()) {
+      if (!isTrenchTag(tagId)) {
+        continue;
+      }
+      Observed o = observe(poseFacingTag(tagId));
+
+      System.out.printf(
+          "full field, facing trench tag %2d: poseObservations=%d tagIds=%s%n",
+          tagId, o.poseObservations(), o.tagIds());
+
+      for (int id : o.tagIds()) {
+        assertTrue(
+            !isTrenchTag(id), "trench tag " + id + " leaked into the solve near tag " + tagId);
+      }
+      if (o.poseObservations() > 0) {
+        mixedFrames++;
+      }
+    }
+    System.out.printf(
+        "PASS: %d trench-tag viewpoints still produced clean poses from neighbouring tags%n",
+        mixedFrames);
+  }
+}


### PR DESCRIPTION
## Problem

The trench tag filter added in `d8409dd` (2026-07-24) never excluded trench tags from pose estimation. It filtered `estimate.targetsUsed` **after** the estimator had already run, so it only affected `inputs.tagIds` — a field consumed solely by `Vision.java:113/121` (building `tagPoses` for AdvantageScope) and `:221` (logging).

Worse, it made the problem invisible. Measured from the match logs:

| | frames w/ tags containing a trench tag | solved from trench tags **only** |
|---|---|---|
| IRI (7/17–18, pre-filter) | **31.4%** | 13.1% |
| WVROX (7/31–8/1, filter present) | 0.0% | 0.0% |

The WVROX zeroes are the filter scrubbing the logs, not the solve. Trench tags were still driving pose the entire event. Over the same period `BelowFloor` rejections — geometrically impossible solves — rose from 18.0% to 24.5% of all vision rejections.

## Fix

Exclusion moved ahead of the estimator. The two strategies need different handling:

- **Single-tag fallback** solves from `result.targets`, so `removeIf` on that list is sufficient — the estimator then picks the best *remaining* tag.
- **Multi-tag PnP was already solved on the coprocessor.** `estimateCoprocMultiTagPose()` only reads the baked `multitagResult.estimatedPose.best` transform, so client-side target filtering cannot change it. A trench tag inside a multi-tag solve can only be *tolerated* or the solve *rejected wholesale*.

Tag IDs moved to a static `Set` in `VisionConstants` with an `isTrenchTag(int)` helper, replacing an 8-element `HashSet` rebuilt per camera per frame inside the vision loop.

Because both strategies set `targetsUsed` from `cameraResult.getTargets()`, the downstream `tagCount`, `ambiguity`, and `avgTagDistance` are now computed on the filtered list as well — those were wrong before even when the pose happened to be fine.

## The multi-tag policy is a constant, not a hardcoded rule

```java
// VisionConstants
public static int minCleanTagsToKeepMultiTag = 2;
```

| Coprocessor multi-tag used | `2` (default, lenient) | `Integer.MAX_VALUE` (strict) |
|---|---|---|
| 13, 14, 15 — clean | keep | keep |
| 13, trench1, trench6 | discard (1 clean) | discard |
| **13, 14, 15, trench1** | **keep** | **discard** |

Only the last row differs. The default is lenient because multi-tag PnP is a least-squares fit — with two or more clean tags it is over-constrained and one bad tag shifts the result rather than flipping it. Rejecting it outright downgrades the frame to a single-tag solve, and the comment on `maxSingleTagDistanceMeters` already records that *every* catastrophic accepted pose in the State/Worlds logs was a single-tag solve.

**Be clear about what lenient costs:** with `2`, a trench tag can still influence a pose, diluted across the fit. If the goal is that trench tags never touch pose under any circumstances, set the constant to `Integer.MAX_VALUE`.

## New logging, because this was unmeasurable

Nothing recorded what the coprocessor's multi-tag solve was *built from* — `TagIds` only shows what was visible and survived filtering. Two fields added to `VisionIOInputs`:

- `MultiTagFiducialIdsUsed` — raw contributing fiducial IDs, recorded **before** the trench filter
- `MultiTagSolvesDiscarded` — how many multi-tag solves the threshold rejected this cycle

One practice match with these logged tells you how often the differing row actually occurs, and therefore which value belongs in `minCleanTagsToKeepMultiTag`. Note this is an `@AutoLog` schema change; sim inherits it via `VisionIOPhotonVisionSim extends VisionIOPhotonVision`, and the regenerated `VisionIOInputsAutoLogged` was verified to carry both fields through `toLog`/`fromLog`/`clone`.

## Verification

`TrenchTagFilterTest` drives the production `VisionIOPhotonVision.updateInputs()` through the PhotonVision simulator against real tags from the configured `k2026RebuiltWelded` layout.

**Trench tag alone on the field** — all 8 IDs:
```
trench tag  1 alone: sawTarget=true  poseObservations=0  tagIds=[]
trench tag  6 alone: sawTarget=true  poseObservations=0  tagIds=[]
...  (7, 12, 17, 22, 23, 28 identical)
```
`sawTarget=true` is the load-bearing assertion: `latestTargetObservation` is computed *before* the filter, so this proves the camera genuinely detected the tag and the filter suppressed the solve — not that the camera saw nothing.

**Non-trench tag alone:** 24/24 produce pose observations, each reporting exactly its own ID. Not over-rejecting.

**Full field, camera facing each trench tag** — the realistic case:
```
facing trench tag  1: poseObservations=6  tagIds=[16, 13, 14, 15]
facing trench tag 17: poseObservations=6  tagIds=[32, 29, 30, 31]
facing trench tag 23: poseObservations=6  tagIds=[3, 4]
```
Pose still solves, sourced only from clean neighbouring tags. All three tests pass under both threshold settings. `./gradlew build` passes.

## Risk

**This reduces accepted vision volume.** On IRI-era rates, up to ~13% of tag-bearing frames disappear entirely and another ~18% lose tags from their solve. Teleop vision coverage was already 92% at WVROX with RobotLeft degraded, and it will drop further. The trade is intentional — those frames were producing the solves `BelowFloor` was catching downstream — but it should be watched.

**Failure mode if wrong:** if trench tags were contributing usable geometry, vision has been thinned without benefit and pose leans harder on odometry between corrections. That is the exact condition behind the q5 runaway (wheels free-spinning ~25 s, odometry integrated ~70 m off-field during a 30 s vision gap, then vision snapped the pose back 49.8 m in one cycle).

## Known gaps for the reviewer

1. **The multi-tag branch is not covered by the test.** Default `SimCameraProperties()` calibration means these frames resolve through the single-tag route, so a coprocessor multi-tag solve containing a trench tag is never constructed in sim. Both the lenient and strict paths are therefore unexercised — the new logging exists precisely because this can only be validated on real hardware.
2. **`latestTargetObservation` is deliberately left unfiltered** — it can still reference a trench tag. It is inert today (`getTargetX()` has no callers) and the test relies on it as the "camera really saw it" signal.
3. **Lenient is a real compromise** of "ignore trench tags properly", per the table above. Flipping to strict is a one-value change.

## Not included

`BuildConstants.java` is modified in my working tree from local gradle runs and is deliberately left out of this PR — it is regenerated at deploy time and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
