### PR TITLE
Log TorqueCurrent for every motor in every real subsystem IO

### DIFF
--- a/src/main/java/frc/robot/subsystems/drive/ModuleIO.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIO.java
@@ -18,6 +18,7 @@ public interface ModuleIO {
     public double driveVelocityRadPerSec = 0.0;
     public double driveAppliedVolts = 0.0;
     public double driveCurrentAmps = 0.0;
+    public double driveTorqueCurrentAmps = 0.0;
 
     public boolean turnConnected = false;
     public boolean turnEncoderConnected = false;
@@ -26,6 +27,7 @@ public interface ModuleIO {
     public double turnVelocityRadPerSec = 0.0;
     public double turnAppliedVolts = 0.0;
     public double turnCurrentAmps = 0.0;
+    public double turnTorqueCurrentAmps = 0.0;
 
     public double[] odometryTimestamps = new double[] {};
     public double[] odometryDrivePositionsRad = new double[] {};

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFX.java
@@ -74,6 +74,7 @@ public class ModuleIOTalonFX implements ModuleIO {
   private final StatusSignal<AngularVelocity> driveVelocity;
   private final StatusSignal<Voltage> driveAppliedVolts;
   private final StatusSignal<Current> driveCurrent;
+  private final StatusSignal<Current> driveTorqueCurrent;
 
   // Inputs from turn motor
   private final StatusSignal<Angle> turnAbsolutePosition;
@@ -82,6 +83,7 @@ public class ModuleIOTalonFX implements ModuleIO {
   private final StatusSignal<AngularVelocity> turnVelocity;
   private final StatusSignal<Voltage> turnAppliedVolts;
   private final StatusSignal<Current> turnCurrent;
+  private final StatusSignal<Current> turnTorqueCurrent;
 
   // Connection debouncers
   private final Debouncer driveConnectedDebounce =
@@ -170,6 +172,7 @@ public class ModuleIOTalonFX implements ModuleIO {
     driveVelocity = driveTalon.getVelocity();
     driveAppliedVolts = driveTalon.getMotorVoltage();
     driveCurrent = driveTalon.getStatorCurrent();
+    driveTorqueCurrent = driveTalon.getTorqueCurrent();
 
     // Create turn status signals
     turnAbsolutePosition = cancoder.getAbsolutePosition();
@@ -178,6 +181,7 @@ public class ModuleIOTalonFX implements ModuleIO {
     turnVelocity = turnTalon.getVelocity();
     turnAppliedVolts = turnTalon.getMotorVoltage();
     turnCurrent = turnTalon.getStatorCurrent();
+    turnTorqueCurrent = turnTalon.getTorqueCurrent();
 
     // Configure periodic frames
     BaseStatusSignal.setUpdateFrequencyForAll(
@@ -187,10 +191,12 @@ public class ModuleIOTalonFX implements ModuleIO {
         driveVelocity,
         driveAppliedVolts,
         driveCurrent,
+        driveTorqueCurrent,
         turnAbsolutePosition,
         turnVelocity,
         turnAppliedVolts,
-        turnCurrent);
+        turnCurrent,
+        turnTorqueCurrent);
     ParentDevice.optimizeBusUtilizationForAll(driveTalon, turnTalon);
   }
 
@@ -198,9 +204,11 @@ public class ModuleIOTalonFX implements ModuleIO {
   public void updateInputs(ModuleIOInputs inputs) {
     // Refresh all signals
     var driveStatus =
-        BaseStatusSignal.refreshAll(drivePosition, driveVelocity, driveAppliedVolts, driveCurrent);
+        BaseStatusSignal.refreshAll(
+            drivePosition, driveVelocity, driveAppliedVolts, driveCurrent, driveTorqueCurrent);
     var turnStatus =
-        BaseStatusSignal.refreshAll(turnPosition, turnVelocity, turnAppliedVolts, turnCurrent);
+        BaseStatusSignal.refreshAll(
+            turnPosition, turnVelocity, turnAppliedVolts, turnCurrent, turnTorqueCurrent);
     var turnEncoderStatus = BaseStatusSignal.refreshAll(turnAbsolutePosition);
 
     // Update drive inputs
@@ -209,6 +217,7 @@ public class ModuleIOTalonFX implements ModuleIO {
     inputs.driveVelocityRadPerSec = Units.rotationsToRadians(driveVelocity.getValueAsDouble());
     inputs.driveAppliedVolts = driveAppliedVolts.getValueAsDouble();
     inputs.driveCurrentAmps = driveCurrent.getValueAsDouble();
+    inputs.driveTorqueCurrentAmps = driveTorqueCurrent.getValueAsDouble();
 
     // Update turn inputs
     inputs.turnConnected = turnConnectedDebounce.calculate(turnStatus.isOK());
@@ -218,6 +227,7 @@ public class ModuleIOTalonFX implements ModuleIO {
     inputs.turnVelocityRadPerSec = Units.rotationsToRadians(turnVelocity.getValueAsDouble());
     inputs.turnAppliedVolts = turnAppliedVolts.getValueAsDouble();
     inputs.turnCurrentAmps = turnCurrent.getValueAsDouble();
+    inputs.turnTorqueCurrentAmps = turnTorqueCurrent.getValueAsDouble();
 
     // Update odometry inputs
     inputs.odometryTimestamps =

--- a/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFXS.java
+++ b/src/main/java/frc/robot/subsystems/drive/ModuleIOTalonFXS.java
@@ -61,6 +61,7 @@ public class ModuleIOTalonFXS implements ModuleIO {
   private final StatusSignal<AngularVelocity> driveVelocity;
   private final StatusSignal<Voltage> driveAppliedVolts;
   private final StatusSignal<Current> driveCurrent;
+  private final StatusSignal<Current> driveTorqueCurrent;
 
   // Inputs from turn motor
   private final StatusSignal<Angle> turnAbsolutePosition;
@@ -69,6 +70,7 @@ public class ModuleIOTalonFXS implements ModuleIO {
   private final StatusSignal<AngularVelocity> turnVelocity;
   private final StatusSignal<Voltage> turnAppliedVolts;
   private final StatusSignal<Current> turnCurrent;
+  private final StatusSignal<Current> turnTorqueCurrent;
 
   // Connection debouncers
   private final Debouncer driveConnectedDebounce =
@@ -166,6 +168,7 @@ public class ModuleIOTalonFXS implements ModuleIO {
     driveVelocity = driveTalon.getVelocity();
     driveAppliedVolts = driveTalon.getMotorVoltage();
     driveCurrent = driveTalon.getStatorCurrent();
+    driveTorqueCurrent = driveTalon.getTorqueCurrent();
 
     // Create turn status signals
     turnAbsolutePosition = candi.getPWM1Position();
@@ -174,6 +177,7 @@ public class ModuleIOTalonFXS implements ModuleIO {
     turnVelocity = turnTalon.getVelocity();
     turnAppliedVolts = turnTalon.getMotorVoltage();
     turnCurrent = turnTalon.getStatorCurrent();
+    turnTorqueCurrent = turnTalon.getTorqueCurrent();
 
     // Configure periodic frames
     BaseStatusSignal.setUpdateFrequencyForAll(
@@ -183,10 +187,12 @@ public class ModuleIOTalonFXS implements ModuleIO {
         driveVelocity,
         driveAppliedVolts,
         driveCurrent,
+        driveTorqueCurrent,
         turnAbsolutePosition,
         turnVelocity,
         turnAppliedVolts,
-        turnCurrent);
+        turnCurrent,
+        turnTorqueCurrent);
     ParentDevice.optimizeBusUtilizationForAll(driveTalon, turnTalon);
   }
 
@@ -194,9 +200,11 @@ public class ModuleIOTalonFXS implements ModuleIO {
   public void updateInputs(ModuleIOInputs inputs) {
     // Refresh all signals
     var driveStatus =
-        BaseStatusSignal.refreshAll(drivePosition, driveVelocity, driveAppliedVolts, driveCurrent);
+        BaseStatusSignal.refreshAll(
+            drivePosition, driveVelocity, driveAppliedVolts, driveCurrent, driveTorqueCurrent);
     var turnStatus =
-        BaseStatusSignal.refreshAll(turnPosition, turnVelocity, turnAppliedVolts, turnCurrent);
+        BaseStatusSignal.refreshAll(
+            turnPosition, turnVelocity, turnAppliedVolts, turnCurrent, turnTorqueCurrent);
     var turnEncoderStatus = BaseStatusSignal.refreshAll(turnAbsolutePosition);
 
     // Update drive inputs
@@ -205,6 +213,7 @@ public class ModuleIOTalonFXS implements ModuleIO {
     inputs.driveVelocityRadPerSec = Units.rotationsToRadians(driveVelocity.getValueAsDouble());
     inputs.driveAppliedVolts = driveAppliedVolts.getValueAsDouble();
     inputs.driveCurrentAmps = driveCurrent.getValueAsDouble();
+    inputs.driveTorqueCurrentAmps = driveTorqueCurrent.getValueAsDouble();
 
     // Update turn inputs
     inputs.turnConnected = turnConnectedDebounce.calculate(turnStatus.isOK());
@@ -214,6 +223,7 @@ public class ModuleIOTalonFXS implements ModuleIO {
     inputs.turnVelocityRadPerSec = Units.rotationsToRadians(turnVelocity.getValueAsDouble());
     inputs.turnAppliedVolts = turnAppliedVolts.getValueAsDouble();
     inputs.turnCurrentAmps = turnCurrent.getValueAsDouble();
+    inputs.turnTorqueCurrentAmps = turnTorqueCurrent.getValueAsDouble();
 
     // Update odometry inputs
     inputs.odometryTimestamps =

--- a/src/main/java/frc/robot/subsystems/flywheel/io/FlywheelIO.java
+++ b/src/main/java/frc/robot/subsystems/flywheel/io/FlywheelIO.java
@@ -38,6 +38,7 @@ public interface FlywheelIO {
     public Voltage leaderAppliedVolts = Volts.of(0);
     public Current leaderSupplyCurrentAmps = Amps.of(0);
     public Current leaderStatorCurrentAmps = Amps.of(0);
+    public Current leaderTorqueCurrentAmps = Amps.of(0);
     public Temperature leaderTemp = Celsius.of(0);
 
     public Angle leaderAngle = Rotations.of(0);
@@ -47,6 +48,7 @@ public interface FlywheelIO {
     public Voltage follower1AppliedVolts = Volts.of(0);
     public Current follower1SupplyCurrentAmps = Amps.of(0);
     public Current follower1StatorCurrentAmps = Amps.of(0);
+    public Current follower1TorqueCurrentAmps = Amps.of(0);
     public Temperature follower1Temp = Celsius.of(0);
 
     // Follower 2 motor
@@ -54,6 +56,7 @@ public interface FlywheelIO {
     public Voltage follower2AppliedVolts = Volts.of(0);
     public Current follower2SupplyCurrentAmps = Amps.of(0);
     public Current follower2StatorCurrentAmps = Amps.of(0);
+    public Current follower2TorqueCurrentAmps = Amps.of(0);
     public Temperature follower2Temp = Celsius.of(0);
 
     // Follower 3 motor
@@ -61,6 +64,7 @@ public interface FlywheelIO {
     public Voltage follower3AppliedVolts = Volts.of(0);
     public Current follower3SupplyCurrentAmps = Amps.of(0);
     public Current follower3StatorCurrentAmps = Amps.of(0);
+    public Current follower3TorqueCurrentAmps = Amps.of(0);
     public Temperature follower3Temp = Celsius.of(0);
 
     // Follower 4 motor
@@ -68,6 +72,7 @@ public interface FlywheelIO {
     public Voltage follower4AppliedVolts = Volts.of(0);
     public Current follower4SupplyCurrentAmps = Amps.of(0);
     public Current follower4StatorCurrentAmps = Amps.of(0);
+    public Current follower4TorqueCurrentAmps = Amps.of(0);
     public Temperature follower4Temp = Celsius.of(0);
   }
 

--- a/src/main/java/frc/robot/subsystems/flywheel/io/FlywheelIOPhoenix6.java
+++ b/src/main/java/frc/robot/subsystems/flywheel/io/FlywheelIOPhoenix6.java
@@ -60,6 +60,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
   private final StatusSignal<Voltage> leaderMotorVoltage;
   private final StatusSignal<Current> leaderSupplyCurrent;
   private final StatusSignal<Current> leaderStatorCurrent;
+  private final StatusSignal<Current> leaderTorqueCurrent;
   private final StatusSignal<Temperature> leaderTemp;
   private final StatusSignal<Double> closedLoopReference;
   private final StatusSignal<Double> closedLoopError;
@@ -70,6 +71,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
   private final StatusSignal<Voltage> follower1MotorVoltage;
   private final StatusSignal<Current> follower1SupplyCurrent;
   private final StatusSignal<Current> follower1StatorCurrent;
+  private final StatusSignal<Current> follower1TorqueCurrent;
   private final StatusSignal<Temperature> follower1Temp;
 
   // Cached status signals for FOLLOWER 2
@@ -77,6 +79,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
   private final StatusSignal<Voltage> follower2MotorVoltage;
   private final StatusSignal<Current> follower2SupplyCurrent;
   private final StatusSignal<Current> follower2StatorCurrent;
+  private final StatusSignal<Current> follower2TorqueCurrent;
   private final StatusSignal<Temperature> follower2Temp;
 
   // Cached status signals for FOLLOWER 3
@@ -84,6 +87,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
   private final StatusSignal<Voltage> follower3MotorVoltage;
   private final StatusSignal<Current> follower3SupplyCurrent;
   private final StatusSignal<Current> follower3StatorCurrent;
+  private final StatusSignal<Current> follower3TorqueCurrent;
   private final StatusSignal<Temperature> follower3Temp;
 
   // Cached status signals for FOLLOWER 4
@@ -91,6 +95,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
   private final StatusSignal<Voltage> follower4MotorVoltage;
   private final StatusSignal<Current> follower4SupplyCurrent;
   private final StatusSignal<Current> follower4StatorCurrent;
+  private final StatusSignal<Current> follower4TorqueCurrent;
   private final StatusSignal<Temperature> follower4Temp;
 
   public FlywheelIOPhoenix6() {
@@ -114,6 +119,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
     leaderMotorVoltage = leader.getMotorVoltage();
     leaderSupplyCurrent = leader.getSupplyCurrent();
     leaderStatorCurrent = leader.getStatorCurrent();
+    leaderTorqueCurrent = leader.getTorqueCurrent();
     leaderTemp = leader.getDeviceTemp();
     closedLoopReference = leader.getClosedLoopReference();
     closedLoopError = leader.getClosedLoopError();
@@ -124,6 +130,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
     follower1MotorVoltage = follower1.getMotorVoltage();
     follower1SupplyCurrent = follower1.getSupplyCurrent();
     follower1StatorCurrent = follower1.getStatorCurrent();
+    follower1TorqueCurrent = follower1.getTorqueCurrent();
     follower1Temp = follower1.getDeviceTemp();
 
     // Cache signal references once — FOLLOWER 2
@@ -131,6 +138,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
     follower2MotorVoltage = follower2.getMotorVoltage();
     follower2SupplyCurrent = follower2.getSupplyCurrent();
     follower2StatorCurrent = follower2.getStatorCurrent();
+    follower2TorqueCurrent = follower2.getTorqueCurrent();
     follower2Temp = follower2.getDeviceTemp();
 
     // Cache signal references once — FOLLOWER 3
@@ -138,6 +146,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
     follower3MotorVoltage = follower3.getMotorVoltage();
     follower3SupplyCurrent = follower3.getSupplyCurrent();
     follower3StatorCurrent = follower3.getStatorCurrent();
+    follower3TorqueCurrent = follower3.getTorqueCurrent();
     follower3Temp = follower3.getDeviceTemp();
 
     // Cache signal references once — FOLLOWER 4
@@ -145,6 +154,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
     follower4MotorVoltage = follower4.getMotorVoltage();
     follower4SupplyCurrent = follower4.getSupplyCurrent();
     follower4StatorCurrent = follower4.getStatorCurrent();
+    follower4TorqueCurrent = follower4.getTorqueCurrent();
     follower4Temp = follower4.getDeviceTemp();
 
     // 50Hz for signals we need every loop (velocity, voltage, current, closed-loop reference)
@@ -154,24 +164,29 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
         leaderMotorVoltage,
         leaderSupplyCurrent,
         leaderStatorCurrent,
+        leaderTorqueCurrent,
         leaderPos,
         closedLoopReference,
         follower1Velocity,
         follower1MotorVoltage,
         follower1SupplyCurrent,
         follower1StatorCurrent,
+        follower1TorqueCurrent,
         follower2Velocity,
         follower2MotorVoltage,
         follower2SupplyCurrent,
         follower2StatorCurrent,
+        follower2TorqueCurrent,
         follower3Velocity,
         follower3MotorVoltage,
         follower3SupplyCurrent,
         follower3StatorCurrent,
+        follower3TorqueCurrent,
         follower4Velocity,
         follower4MotorVoltage,
         follower4SupplyCurrent,
-        follower4StatorCurrent);
+        follower4StatorCurrent,
+        follower4TorqueCurrent);
 
     // 10Hz for diagnostic-only signals (temperature, closed-loop error)
     BaseStatusSignal.setUpdateFrequencyForAll(
@@ -259,6 +274,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
         leaderMotorVoltage,
         leaderSupplyCurrent,
         leaderStatorCurrent,
+        leaderTorqueCurrent,
         leaderTemp,
         leaderPos,
         closedLoopReference,
@@ -267,21 +283,25 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
         follower1MotorVoltage,
         follower1SupplyCurrent,
         follower1StatorCurrent,
+        follower1TorqueCurrent,
         follower1Temp,
         follower2Velocity,
         follower2MotorVoltage,
         follower2SupplyCurrent,
         follower2StatorCurrent,
+        follower2TorqueCurrent,
         follower2Temp,
         follower3Velocity,
         follower3MotorVoltage,
         follower3SupplyCurrent,
         follower3StatorCurrent,
+        follower3TorqueCurrent,
         follower3Temp,
         follower4Velocity,
         follower4MotorVoltage,
         follower4SupplyCurrent,
         follower4StatorCurrent,
+        follower4TorqueCurrent,
         follower4Temp);
 
     // Leader motor — read from cache
@@ -289,6 +309,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
     inputs.leaderAppliedVolts = leaderMotorVoltage.getValue();
     inputs.leaderSupplyCurrentAmps = leaderSupplyCurrent.getValue();
     inputs.leaderStatorCurrentAmps = leaderStatorCurrent.getValue();
+    inputs.leaderTorqueCurrentAmps = leaderTorqueCurrent.getValue();
     inputs.leaderTemp = leaderTemp.getValue();
     inputs.leaderAngle = leaderPos.getValue();
 
@@ -297,6 +318,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
     inputs.follower1AppliedVolts = follower1MotorVoltage.getValue();
     inputs.follower1SupplyCurrentAmps = follower1SupplyCurrent.getValue();
     inputs.follower1StatorCurrentAmps = follower1StatorCurrent.getValue();
+    inputs.follower1TorqueCurrentAmps = follower1TorqueCurrent.getValue();
     inputs.follower1Temp = follower1Temp.getValue();
 
     // Follower 2 motor — read from cache
@@ -304,6 +326,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
     inputs.follower2AppliedVolts = follower2MotorVoltage.getValue();
     inputs.follower2SupplyCurrentAmps = follower2SupplyCurrent.getValue();
     inputs.follower2StatorCurrentAmps = follower2StatorCurrent.getValue();
+    inputs.follower2TorqueCurrentAmps = follower2TorqueCurrent.getValue();
     inputs.follower2Temp = follower2Temp.getValue();
 
     // Follower 3 motor — read from cache
@@ -311,6 +334,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
     inputs.follower3AppliedVolts = follower3MotorVoltage.getValue();
     inputs.follower3SupplyCurrentAmps = follower3SupplyCurrent.getValue();
     inputs.follower3StatorCurrentAmps = follower3StatorCurrent.getValue();
+    inputs.follower3TorqueCurrentAmps = follower3TorqueCurrent.getValue();
     inputs.follower3Temp = follower3Temp.getValue();
 
     // Follower 4 motor — read from cache
@@ -318,6 +342,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
     inputs.follower4AppliedVolts = follower4MotorVoltage.getValue();
     inputs.follower4SupplyCurrentAmps = follower4SupplyCurrent.getValue();
     inputs.follower4StatorCurrentAmps = follower4StatorCurrent.getValue();
+    inputs.follower4TorqueCurrentAmps = follower4TorqueCurrent.getValue();
     inputs.follower4Temp = follower4Temp.getValue();
 
     // Combined flywheel velocity (use leader velocity as representative)

--- a/src/main/java/frc/robot/subsystems/hood/io/HoodIO.java
+++ b/src/main/java/frc/robot/subsystems/hood/io/HoodIO.java
@@ -20,6 +20,7 @@ public interface HoodIO {
     public Voltage hoodVoltage = Volts.of(0);
     public Current hoodSupplyCurrent = Amps.of(0);
     public Current hoodStatorCurrent = Amps.of(0);
+    public Current hoodTorqueCurrent = Amps.of(0);
     public Temperature hoodTemperature = Celsius.of(0);
     public AngularVelocity hoodVelocity = DegreesPerSecond.of(0);
     public Angle hoodPosition = Degrees.of(0);

--- a/src/main/java/frc/robot/subsystems/hood/io/HoodIOReal.java
+++ b/src/main/java/frc/robot/subsystems/hood/io/HoodIOReal.java
@@ -34,6 +34,7 @@ public class HoodIOReal implements HoodIO {
   private final StatusSignal<Voltage> motorVoltage;
   private final StatusSignal<Current> statorCurrent;
   private final StatusSignal<Current> supplyCurrent;
+  private final StatusSignal<Current> torqueCurrent;
   private final StatusSignal<Temperature> deviceTemp;
   private final StatusSignal<Angle> devicePos;
   private final StatusSignal<Double> closedLoopReference;
@@ -52,6 +53,7 @@ public class HoodIOReal implements HoodIO {
     motorVoltage = hoodMotor.getMotorVoltage();
     statorCurrent = hoodMotor.getStatorCurrent();
     supplyCurrent = hoodMotor.getSupplyCurrent();
+    torqueCurrent = hoodMotor.getTorqueCurrent();
     deviceTemp = hoodMotor.getDeviceTemp();
     devicePos = hoodMotor.getPosition();
     closedLoopReference = hoodMotor.getClosedLoopReference();
@@ -60,7 +62,14 @@ public class HoodIOReal implements HoodIO {
     // 50Hz for signals we need every loop (velocity, voltage, current, position, closed-loop
     // reference)
     BaseStatusSignal.setUpdateFrequencyForAll(
-        50.0, velocity, motorVoltage, statorCurrent, supplyCurrent, devicePos, closedLoopReference);
+        50.0,
+        velocity,
+        motorVoltage,
+        statorCurrent,
+        supplyCurrent,
+        torqueCurrent,
+        devicePos,
+        closedLoopReference);
 
     // 10Hz for diagnostic-only signals (temperature, closed-loop error)
     BaseStatusSignal.setUpdateFrequencyForAll(10.0, deviceTemp, closedLoopError);
@@ -156,6 +165,7 @@ public class HoodIOReal implements HoodIO {
         motorVoltage,
         statorCurrent,
         supplyCurrent,
+        torqueCurrent,
         deviceTemp,
         devicePos,
         closedLoopReference,
@@ -169,6 +179,7 @@ public class HoodIOReal implements HoodIO {
     inputs.hoodVoltage = motorVoltage.getValue();
     inputs.hoodStatorCurrent = statorCurrent.getValue();
     inputs.hoodSupplyCurrent = supplyCurrent.getValue();
+    inputs.hoodTorqueCurrent = torqueCurrent.getValue();
     inputs.hoodTemperature = deviceTemp.getValue();
     // closedLoopReference and closedLoopError are raw doubles in mechanism rotations.
     // Convert to degrees so all hood angles are in degrees throughout the codebase.

--- a/src/main/java/frc/robot/subsystems/intakePivot/io/IntakePivotIO.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/io/IntakePivotIO.java
@@ -26,6 +26,7 @@ public interface IntakePivotIO {
     public Voltage intakePivotVoltage = Volts.of(0);
     public Current intakePivotSupplyCurrent = Amps.of(0);
     public Current intakePivotStatorCurrent = Amps.of(0);
+    public Current intakePivotTorqueCurrent = Amps.of(0);
     public Temperature intakePivotTemperature = Celsius.of(0);
     public AngularVelocity intakePivotVelocity = RotationsPerSecond.of(0);
     public Angle intakePivotPosition = Rotations.of(0);

--- a/src/main/java/frc/robot/subsystems/intakePivot/io/IntakePivotIOReal.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/io/IntakePivotIOReal.java
@@ -52,6 +52,7 @@ public class IntakePivotIOReal implements IntakePivotIO {
   private final StatusSignal<Voltage> motorVoltage;
   private final StatusSignal<Current> statorCurrent;
   private final StatusSignal<Current> supplyCurrent;
+  private final StatusSignal<Current> torqueCurrent;
   private final StatusSignal<Temperature> deviceTemp;
   private final StatusSignal<Double> closedLoopReference;
   private final StatusSignal<Double> closedLoopError;
@@ -71,6 +72,7 @@ public class IntakePivotIOReal implements IntakePivotIO {
     motorVoltage = intakePivotMotor.getMotorVoltage();
     statorCurrent = intakePivotMotor.getStatorCurrent();
     supplyCurrent = intakePivotMotor.getSupplyCurrent();
+    torqueCurrent = intakePivotMotor.getTorqueCurrent();
     deviceTemp = intakePivotMotor.getDeviceTemp();
     closedLoopReference = intakePivotMotor.getClosedLoopReference();
     closedLoopError = intakePivotMotor.getClosedLoopError();
@@ -86,6 +88,7 @@ public class IntakePivotIOReal implements IntakePivotIO {
         motorVoltage,
         statorCurrent,
         supplyCurrent,
+        torqueCurrent,
         encoderPosition,
         closedLoopReference);
 
@@ -172,6 +175,7 @@ public class IntakePivotIOReal implements IntakePivotIO {
         motorVoltage,
         statorCurrent,
         supplyCurrent,
+        torqueCurrent,
         deviceTemp,
         closedLoopReference,
         closedLoopError,
@@ -183,6 +187,7 @@ public class IntakePivotIOReal implements IntakePivotIO {
     inputs.intakePivotVoltage = motorVoltage.getValue();
     inputs.intakePivotStatorCurrent = statorCurrent.getValue();
     inputs.intakePivotSupplyCurrent = supplyCurrent.getValue();
+    inputs.intakePivotTorqueCurrent = torqueCurrent.getValue();
     inputs.intakePivotTemperature = deviceTemp.getValue();
     inputs.intakePivotClosedLoopReference = closedLoopReference.getValueAsDouble();
     inputs.intakePivotClosedLoopError = closedLoopError.getValueAsDouble();

--- a/src/main/java/frc/robot/subsystems/intakeRoller/io/intakeRollerIO.java
+++ b/src/main/java/frc/robot/subsystems/intakeRoller/io/intakeRollerIO.java
@@ -20,6 +20,7 @@ public interface intakeRollerIO {
     public Voltage intakeRollerVoltage = Volts.of(0);
     public Current intakeRollerSupplyCurrent = Amps.of(0);
     public Current intakeRollerStatorCurrent = Amps.of(0);
+    public Current intakeRollerTorqueCurrent = Amps.of(0);
     public Temperature intakeRollerTemperature = Celsius.of(0);
     public AngularVelocity intakeRollerVelocity = RotationsPerSecond.of(0);
     public AngularVelocity rollerClosedLoopReference = RotationsPerSecond.of(0);
@@ -28,6 +29,7 @@ public interface intakeRollerIO {
     public Voltage intakeRollerFollowerVoltage = Volts.of(0);
     public Current intakeRollerFollowerSupplyCurrent = Amps.of(0);
     public Current intakeRollerFollowerStatorCurrent = Amps.of(0);
+    public Current intakeRollerFollowerTorqueCurrent = Amps.of(0);
     public Temperature intakeRollerFollowerTemperature = Celsius.of(0);
     public AngularVelocity intakeRollerFollowerVelocity = RotationsPerSecond.of(0);
     public AngularVelocity rollerFollowerClosedLoopReference = RotationsPerSecond.of(0);

--- a/src/main/java/frc/robot/subsystems/intakeRoller/io/intakeRollerIOReal.java
+++ b/src/main/java/frc/robot/subsystems/intakeRoller/io/intakeRollerIOReal.java
@@ -38,6 +38,7 @@ public class intakeRollerIOReal implements intakeRollerIO {
   private final StatusSignal<AngularVelocity> velocity;
   private final StatusSignal<Current> statorCurrent;
   private final StatusSignal<Current> supplyCurrent;
+  private final StatusSignal<Current> torqueCurrent;
   private final StatusSignal<Voltage> motorVoltage;
   private final StatusSignal<Temperature> deviceTemp;
   private final StatusSignal<Double> closedLoopReference;
@@ -46,6 +47,7 @@ public class intakeRollerIOReal implements intakeRollerIO {
   private final StatusSignal<AngularVelocity> Followervelocity;
   private final StatusSignal<Current> FollowerstatorCurrent;
   private final StatusSignal<Current> FollowersupplyCurrent;
+  private final StatusSignal<Current> FollowertorqueCurrent;
   private final StatusSignal<Voltage> FollowermotorVoltage;
   private final StatusSignal<Temperature> FollowerdeviceTemp;
   private final StatusSignal<Double> FollowerclosedLoopReference;
@@ -69,6 +71,7 @@ public class intakeRollerIOReal implements intakeRollerIO {
     velocity = intakeRollerLeader.getVelocity();
     statorCurrent = intakeRollerLeader.getStatorCurrent();
     supplyCurrent = intakeRollerLeader.getSupplyCurrent();
+    torqueCurrent = intakeRollerLeader.getTorqueCurrent();
     motorVoltage = intakeRollerLeader.getMotorVoltage();
     deviceTemp = intakeRollerLeader.getDeviceTemp();
     closedLoopReference = intakeRollerLeader.getClosedLoopReference();
@@ -77,6 +80,7 @@ public class intakeRollerIOReal implements intakeRollerIO {
     Followervelocity = intakeRollerFollower.getVelocity();
     FollowerstatorCurrent = intakeRollerFollower.getStatorCurrent();
     FollowersupplyCurrent = intakeRollerFollower.getSupplyCurrent();
+    FollowertorqueCurrent = intakeRollerFollower.getTorqueCurrent();
     FollowermotorVoltage = intakeRollerFollower.getMotorVoltage();
     FollowerdeviceTemp = intakeRollerFollower.getDeviceTemp();
     FollowerclosedLoopReference = intakeRollerFollower.getClosedLoopReference();
@@ -85,7 +89,13 @@ public class intakeRollerIOReal implements intakeRollerIO {
 
     // 50Hz for signals we need every loop (velocity, voltage, current, closed-loop reference)
     BaseStatusSignal.setUpdateFrequencyForAll(
-        50.0, velocity, statorCurrent, supplyCurrent, motorVoltage, closedLoopReference);
+        50.0,
+        velocity,
+        statorCurrent,
+        supplyCurrent,
+        torqueCurrent,
+        motorVoltage,
+        closedLoopReference);
 
     // 10Hz for diagnostic-only signals (temperature, closed-loop error)
     BaseStatusSignal.setUpdateFrequencyForAll(10.0, deviceTemp, closedLoopError);
@@ -137,6 +147,7 @@ public class intakeRollerIOReal implements intakeRollerIO {
         velocity,
         statorCurrent,
         supplyCurrent,
+        torqueCurrent,
         motorVoltage,
         deviceTemp,
         closedLoopReference,
@@ -145,6 +156,7 @@ public class intakeRollerIOReal implements intakeRollerIO {
         Followervelocity,
         FollowerstatorCurrent,
         FollowersupplyCurrent,
+        FollowertorqueCurrent,
         FollowermotorVoltage,
         FollowerdeviceTemp,
         FollowerclosedLoopReference,
@@ -155,6 +167,7 @@ public class intakeRollerIOReal implements intakeRollerIO {
     inputs.intakeRollerVelocity = velocity.getValue();
     inputs.intakeRollerStatorCurrent = statorCurrent.getValue();
     inputs.intakeRollerSupplyCurrent = supplyCurrent.getValue();
+    inputs.intakeRollerTorqueCurrent = torqueCurrent.getValue();
     inputs.intakeRollerVoltage = motorVoltage.getValue();
     inputs.intakeRollerTemperature = deviceTemp.getValue();
     inputs.rollerClosedLoopReference =
@@ -164,6 +177,7 @@ public class intakeRollerIOReal implements intakeRollerIO {
     inputs.intakeRollerFollowerVelocity = Followervelocity.getValue();
     inputs.intakeRollerFollowerStatorCurrent = FollowerstatorCurrent.getValue();
     inputs.intakeRollerFollowerSupplyCurrent = FollowersupplyCurrent.getValue();
+    inputs.intakeRollerFollowerTorqueCurrent = FollowertorqueCurrent.getValue();
     inputs.intakeRollerFollowerVoltage = FollowermotorVoltage.getValue();
     inputs.intakeRollerFollowerTemperature = FollowerdeviceTemp.getValue();
     inputs.rollerFollowerClosedLoopReference =

--- a/src/main/java/frc/robot/subsystems/lowerFeeder/io/LowerFeederIO.java
+++ b/src/main/java/frc/robot/subsystems/lowerFeeder/io/LowerFeederIO.java
@@ -20,6 +20,7 @@ public interface LowerFeederIO {
     public Voltage lowerFeederVoltage = Volts.of(0);
     public Current lowerFeederStatorAmps = Amps.of(0);
     public Current lowerFeederSupplyAmps = Amps.of(0);
+    public Current lowerFeederTorqueCurrentAmps = Amps.of(0);
     public AngularVelocity lowerFeederMotorVelocity = RotationsPerSecond.of(0);
     public Temperature lowerFeederMotorTemperature = Celsius.of(0);
     public AngularVelocity lowerFeederClosedLoopReference = RotationsPerSecond.of(0);

--- a/src/main/java/frc/robot/subsystems/lowerFeeder/io/LowerFeederIOReal.java
+++ b/src/main/java/frc/robot/subsystems/lowerFeeder/io/LowerFeederIOReal.java
@@ -34,6 +34,7 @@ public class LowerFeederIOReal implements LowerFeederIO {
   private final StatusSignal<AngularVelocity> velocity;
   private final StatusSignal<Current> statorCurrent;
   private final StatusSignal<Current> supplyCurrent;
+  private final StatusSignal<Current> torqueCurrent;
   private final StatusSignal<Voltage> motorVoltage;
   private final StatusSignal<Temperature> deviceTemp;
   private final StatusSignal<Double> closedLoopReference;
@@ -48,6 +49,7 @@ public class LowerFeederIOReal implements LowerFeederIO {
     velocity = lowerFeederMotor.getVelocity();
     statorCurrent = lowerFeederMotor.getStatorCurrent();
     supplyCurrent = lowerFeederMotor.getSupplyCurrent();
+    torqueCurrent = lowerFeederMotor.getTorqueCurrent();
     motorVoltage = lowerFeederMotor.getMotorVoltage();
     deviceTemp = lowerFeederMotor.getDeviceTemp();
     closedLoopReference = lowerFeederMotor.getClosedLoopReference();
@@ -56,7 +58,13 @@ public class LowerFeederIOReal implements LowerFeederIO {
 
     // 50Hz for signals we need every loop (velocity, voltage, current, closed-loop reference)
     BaseStatusSignal.setUpdateFrequencyForAll(
-        50.0, velocity, statorCurrent, supplyCurrent, motorVoltage, closedLoopReference);
+        50.0,
+        velocity,
+        statorCurrent,
+        supplyCurrent,
+        torqueCurrent,
+        motorVoltage,
+        closedLoopReference);
 
     // 10Hz for diagnostic-only signals (temperature, closed-loop error)
     BaseStatusSignal.setUpdateFrequencyForAll(10.0, deviceTemp, closedLoopError);
@@ -106,6 +114,7 @@ public class LowerFeederIOReal implements LowerFeederIO {
         velocity,
         statorCurrent,
         supplyCurrent,
+        torqueCurrent,
         motorVoltage,
         deviceTemp,
         closedLoopReference,
@@ -116,6 +125,7 @@ public class LowerFeederIOReal implements LowerFeederIO {
     inputs.lowerFeederMotorVelocity = velocity.getValue();
     inputs.lowerFeederStatorAmps = statorCurrent.getValue();
     inputs.lowerFeederSupplyAmps = supplyCurrent.getValue();
+    inputs.lowerFeederTorqueCurrentAmps = torqueCurrent.getValue();
     inputs.lowerFeederVoltage = motorVoltage.getValue();
     inputs.lowerFeederMotorTemperature = deviceTemp.getValue();
     inputs.lowerFeederClosedLoopReference =

--- a/src/main/java/frc/robot/subsystems/prestage/io/PrestageIO.java
+++ b/src/main/java/frc/robot/subsystems/prestage/io/PrestageIO.java
@@ -24,6 +24,9 @@ public interface PrestageIO {
     public Current prestageRightStatorAmps = Amps.of(0);
     public Current prestageRightSupplyAmps = Amps.of(0);
 
+    public Current prestageLeftTorqueCurrentAmps = Amps.of(0);
+    public Current prestageRightTorqueCurrentAmps = Amps.of(0);
+
     public AngularVelocity prestageLeftVelocity = RotationsPerSecond.of(0);
     public AngularVelocity prestageRightVelocity = RotationsPerSecond.of(0);
 

--- a/src/main/java/frc/robot/subsystems/prestage/io/PrestageIOReal.java
+++ b/src/main/java/frc/robot/subsystems/prestage/io/PrestageIOReal.java
@@ -37,6 +37,7 @@ public class PrestageIOReal implements PrestageIO {
   private final StatusSignal<AngularVelocity> leftVelocity;
   private final StatusSignal<Current> leftStatorCurrent;
   private final StatusSignal<Current> leftSupplyCurrent;
+  private final StatusSignal<Current> leftTorqueCurrent;
   private final StatusSignal<Voltage> leftMotorVoltage;
   private final StatusSignal<Temperature> leftDeviceTemp;
   private final StatusSignal<Double> leftClosedLoopReference;
@@ -47,6 +48,7 @@ public class PrestageIOReal implements PrestageIO {
   private final StatusSignal<AngularVelocity> rightVelocity;
   private final StatusSignal<Current> rightStatorCurrent;
   private final StatusSignal<Current> rightSupplyCurrent;
+  private final StatusSignal<Current> rightTorqueCurrent;
   private final StatusSignal<Voltage> rightMotorVoltage;
   private final StatusSignal<Temperature> rightDeviceTemp;
   private final StatusSignal<Double> rightClosedLoopReference;
@@ -66,6 +68,7 @@ public class PrestageIOReal implements PrestageIO {
     leftVelocity = prestageLeft.getVelocity();
     leftStatorCurrent = prestageLeft.getStatorCurrent();
     leftSupplyCurrent = prestageLeft.getSupplyCurrent();
+    leftTorqueCurrent = prestageLeft.getTorqueCurrent();
     leftMotorVoltage = prestageLeft.getMotorVoltage();
     leftDeviceTemp = prestageLeft.getDeviceTemp();
     leftClosedLoopReference = prestageLeft.getClosedLoopReference();
@@ -76,6 +79,7 @@ public class PrestageIOReal implements PrestageIO {
     rightVelocity = prestageRight.getVelocity();
     rightStatorCurrent = prestageRight.getStatorCurrent();
     rightSupplyCurrent = prestageRight.getSupplyCurrent();
+    rightTorqueCurrent = prestageRight.getTorqueCurrent();
     rightMotorVoltage = prestageRight.getMotorVoltage();
     rightDeviceTemp = prestageRight.getDeviceTemp();
     rightClosedLoopReference = prestageRight.getClosedLoopReference();
@@ -88,11 +92,13 @@ public class PrestageIOReal implements PrestageIO {
         leftVelocity,
         leftStatorCurrent,
         leftSupplyCurrent,
+        leftTorqueCurrent,
         leftMotorVoltage,
         leftClosedLoopReference,
         rightVelocity,
         rightStatorCurrent,
         rightSupplyCurrent,
+        rightTorqueCurrent,
         rightMotorVoltage,
         rightClosedLoopReference);
 
@@ -147,6 +153,7 @@ public class PrestageIOReal implements PrestageIO {
         leftVelocity,
         leftStatorCurrent,
         leftSupplyCurrent,
+        leftTorqueCurrent,
         leftMotorVoltage,
         leftDeviceTemp,
         leftClosedLoopReference,
@@ -155,6 +162,7 @@ public class PrestageIOReal implements PrestageIO {
         rightVelocity,
         rightStatorCurrent,
         rightSupplyCurrent,
+        rightTorqueCurrent,
         rightMotorVoltage,
         rightDeviceTemp,
         rightClosedLoopReference,
@@ -165,6 +173,7 @@ public class PrestageIOReal implements PrestageIO {
     inputs.prestageLeftVelocity = leftVelocity.getValue();
     inputs.prestageLeftStatorAmps = leftStatorCurrent.getValue();
     inputs.prestageLeftSupplyAmps = leftSupplyCurrent.getValue();
+    inputs.prestageLeftTorqueCurrentAmps = leftTorqueCurrent.getValue();
     inputs.prestageLeftVoltage = leftMotorVoltage.getValue();
     inputs.prestageLeftTemperature = leftDeviceTemp.getValue();
     inputs.prestageLeftClosedLoopReference =
@@ -177,6 +186,7 @@ public class PrestageIOReal implements PrestageIO {
     inputs.prestageRightVelocity = rightVelocity.getValue();
     inputs.prestageRightStatorAmps = rightStatorCurrent.getValue();
     inputs.prestageRightSupplyAmps = rightSupplyCurrent.getValue();
+    inputs.prestageRightTorqueCurrentAmps = rightTorqueCurrent.getValue();
     inputs.prestageRightVoltage = rightMotorVoltage.getValue();
     inputs.prestageRightTemperature = rightDeviceTemp.getValue();
     inputs.prestageRightClosedLoopReference =

--- a/src/main/java/frc/robot/subsystems/transport/io/TransportIO.java
+++ b/src/main/java/frc/robot/subsystems/transport/io/TransportIO.java
@@ -20,6 +20,7 @@ public interface TransportIO {
     public Voltage TransportVoltage = Volts.of(0);
     public Current TransportStatorAmps = Amps.of(0);
     public Current TransportSupplyAmps = Amps.of(0);
+    public Current TransportTorqueCurrentAmps = Amps.of(0);
     public AngularVelocity TransportMotorVelocity = RotationsPerSecond.of(0);
     public Temperature TransportMotorTemperature = Celsius.of(0);
     public AngularVelocity transportClosedLoopReference = RotationsPerSecond.of(0);

--- a/src/main/java/frc/robot/subsystems/transport/io/TransportIOReal.java
+++ b/src/main/java/frc/robot/subsystems/transport/io/TransportIOReal.java
@@ -34,6 +34,7 @@ public class TransportIOReal implements TransportIO {
   private final StatusSignal<AngularVelocity> velocity;
   private final StatusSignal<Current> statorCurrent;
   private final StatusSignal<Current> supplyCurrent;
+  private final StatusSignal<Current> torqueCurrent;
   private final StatusSignal<Voltage> motorVoltage;
   private final StatusSignal<Temperature> deviceTemp;
   private final StatusSignal<Double> closedLoopReference;
@@ -48,6 +49,7 @@ public class TransportIOReal implements TransportIO {
     velocity = transportMotor.getVelocity();
     statorCurrent = transportMotor.getStatorCurrent();
     supplyCurrent = transportMotor.getSupplyCurrent();
+    torqueCurrent = transportMotor.getTorqueCurrent();
     motorVoltage = transportMotor.getMotorVoltage();
     deviceTemp = transportMotor.getDeviceTemp();
     closedLoopReference = transportMotor.getClosedLoopReference();
@@ -56,7 +58,13 @@ public class TransportIOReal implements TransportIO {
 
     // 50Hz for signals we need every loop (velocity, voltage, current)
     BaseStatusSignal.setUpdateFrequencyForAll(
-        50.0, velocity, statorCurrent, supplyCurrent, motorVoltage, closedLoopReference);
+        50.0,
+        velocity,
+        statorCurrent,
+        supplyCurrent,
+        torqueCurrent,
+        motorVoltage,
+        closedLoopReference);
 
     // 10Hz for diagnostic-only signals (temperature, closed-loop error)
     BaseStatusSignal.setUpdateFrequencyForAll(10.0, deviceTemp, closedLoopError);
@@ -106,6 +114,7 @@ public class TransportIOReal implements TransportIO {
         velocity,
         statorCurrent,
         supplyCurrent,
+        torqueCurrent,
         motorVoltage,
         deviceTemp,
         closedLoopReference,
@@ -116,6 +125,7 @@ public class TransportIOReal implements TransportIO {
     inputs.TransportMotorVelocity = velocity.getValue();
     inputs.TransportStatorAmps = statorCurrent.getValue();
     inputs.TransportSupplyAmps = supplyCurrent.getValue();
+    inputs.TransportTorqueCurrentAmps = torqueCurrent.getValue();
     inputs.TransportVoltage = motorVoltage.getValue();
     inputs.TransportMotorTemperature = deviceTemp.getValue();
     inputs.transportClosedLoopReference =

--- a/src/main/java/frc/robot/subsystems/upperFeeder/io/UpperFeederIO.java
+++ b/src/main/java/frc/robot/subsystems/upperFeeder/io/UpperFeederIO.java
@@ -20,6 +20,7 @@ public interface UpperFeederIO {
     public Voltage upperFeederVoltage = Volts.of(0);
     public Current upperFeederStatorAmps = Amps.of(0);
     public Current upperFeederSupplyAmps = Amps.of(0);
+    public Current upperFeederTorqueCurrentAmps = Amps.of(0);
     public AngularVelocity upperFeederMotorVelocity = RotationsPerSecond.of(0);
     public Temperature upperFeederMotorTemperature = Celsius.of(0);
     public AngularVelocity upperFeederClosedLoopReference = RotationsPerSecond.of(0);

--- a/src/main/java/frc/robot/subsystems/upperFeeder/io/UpperFeederIOReal.java
+++ b/src/main/java/frc/robot/subsystems/upperFeeder/io/UpperFeederIOReal.java
@@ -34,6 +34,7 @@ public class UpperFeederIOReal implements UpperFeederIO {
   private final StatusSignal<AngularVelocity> velocity;
   private final StatusSignal<Current> statorCurrent;
   private final StatusSignal<Current> supplyCurrent;
+  private final StatusSignal<Current> torqueCurrent;
   private final StatusSignal<Voltage> motorVoltage;
   private final StatusSignal<Temperature> deviceTemp;
   private final StatusSignal<Double> closedLoopReference;
@@ -48,6 +49,7 @@ public class UpperFeederIOReal implements UpperFeederIO {
     velocity = upperFeederMotor.getVelocity();
     statorCurrent = upperFeederMotor.getStatorCurrent();
     supplyCurrent = upperFeederMotor.getSupplyCurrent();
+    torqueCurrent = upperFeederMotor.getTorqueCurrent();
     motorVoltage = upperFeederMotor.getMotorVoltage();
     deviceTemp = upperFeederMotor.getDeviceTemp();
     closedLoopReference = upperFeederMotor.getClosedLoopReference();
@@ -56,7 +58,13 @@ public class UpperFeederIOReal implements UpperFeederIO {
 
     // 50Hz for signals we need every loop (velocity, voltage, current, closed-loop reference)
     BaseStatusSignal.setUpdateFrequencyForAll(
-        50.0, velocity, statorCurrent, supplyCurrent, motorVoltage, closedLoopReference);
+        50.0,
+        velocity,
+        statorCurrent,
+        supplyCurrent,
+        torqueCurrent,
+        motorVoltage,
+        closedLoopReference);
 
     // 10Hz for diagnostic-only signals (temperature, closed-loop error)
     BaseStatusSignal.setUpdateFrequencyForAll(10.0, deviceTemp, closedLoopError);
@@ -106,6 +114,7 @@ public class UpperFeederIOReal implements UpperFeederIO {
         velocity,
         statorCurrent,
         supplyCurrent,
+        torqueCurrent,
         motorVoltage,
         deviceTemp,
         closedLoopReference,
@@ -116,6 +125,7 @@ public class UpperFeederIOReal implements UpperFeederIO {
     inputs.upperFeederMotorVelocity = velocity.getValue();
     inputs.upperFeederStatorAmps = statorCurrent.getValue();
     inputs.upperFeederSupplyAmps = supplyCurrent.getValue();
+    inputs.upperFeederTorqueCurrentAmps = torqueCurrent.getValue();
     inputs.upperFeederVoltage = motorVoltage.getValue();
     inputs.upperFeederMotorTemperature = deviceTemp.getValue();
     inputs.upperFeederClosedLoopReference =


### PR DESCRIPTION
## What

Adds a `TorqueCurrent` cached `StatusSignal` and a matching `@AutoLog` input for every motor in every real subsystem IO — 8 mechanism motors + the 8 swerve motors.

| Subsystem | Motors | New log channel(s) |
|---|---|---|
| Flywheel | leader + 4 followers | `Leader/Follower1-4TorqueCurrentAmps` |
| Hood | 1 | `HoodTorqueCurrent` |
| Intake pivot | 1 | `IntakePivotTorqueCurrent` |
| Intake roller | leader + follower | `IntakeRoller[Follower]TorqueCurrent` |
| Lower feeder | 1 | `LowerFeederTorqueCurrentAmps` |
| Upper feeder | 1 | `UpperFeederTorqueCurrentAmps` |
| Prestage | left + right | `PrestageLeft/RightTorqueCurrentAmps` |
| Transport | 1 | `TransportTorqueCurrentAmps` |
| Drive (per module) | drive + steer | `DriveTorqueCurrentAmps`, `TurnTorqueCurrentAmps` |

## Why

Stator and supply current are already logged everywhere, but neither is the torque-producing current the FOC controllers actually command. Every mechanism here runs a `*TorqueCurrentFOC` request, so torque current *is* the control signal. Without it, a stalled roller and a healthy spun-up roller drawing similar stator current look the same in replay.

## How

Same cached-signal pattern already used in these files — no new pattern introduced:

1. Cache the `StatusSignal<Current>` reference once in the constructor
2. Register it at **50 Hz**, alongside stator/supply current (not in the 10 Hz diagnostic group — it's a control signal, not a diagnostic)
3. Add it to the existing batched `BaseStatusSignal.refreshAll(...)` call
4. Read from cache into the `@AutoLog` inputs

## CAN bus impact: none

Phoenix 6 packs `TorqueCurrent` into the same status frame as `StatorCurrent`, which is already registered at 50 Hz on every one of these motors. Requesting it does not add a periodic frame. Worth confirming against bus utilization in Tuner X on the first real deploy, given the loop-overrun work in progress.

## Risk

Additive logging only. No control paths, gains, limits, inversions, CAN IDs, or timeouts touched. `@AutoLog` schemas grew by one field per motor — new fields, no renames or removals, so old logs still replay.

## Notes for review

- **`ModuleIO`/drive is touched.** Per the safety rules this is high-risk territory, so calling it out explicitly: the change to `ModuleIOTalonFX` is two cached signals, two frequency registrations, two `refreshAll` args, and two input assignments. Odometry signals, the 250 Hz registration, and `PhoenixOdometryThread` are untouched.
- **`ModuleIOTalonFXS` kept in sync** even though nothing constructs it today, so the two module implementations don't drift.
- **Sim IOs unchanged.** The new channels log 0 under `simulateJava`. The sim implementations don't model torque current (`FlywheelIOSim` only injects rotor position/velocity into `TalonFXSimState`), so a populated value would be fiction. The schema is shared via the generated `*AutoLogged` classes, so real and sim still match.
- **Pre-existing, not fixed here:** in `intakeRollerIOReal`, the *follower's* signals were never registered with `setUpdateFrequencyForAll`, so after `optimizeBusUtilization()` they publish at the 4 Hz default. Its torque current was added to `refreshAll` consistently with its siblings, but it will be slow like them. Flagging rather than fixing to keep this diff to one thing.

## Verification

- `./gradlew compileJava` ✅
- `./gradlew spotlessCheck` ✅
- `./gradlew build` (incl. tests + annotation processor) ✅
- Confirmed the `*AutoLogged` classes regenerated with the new `toLog`/`fromLog`/`clone` entries

Not yet run on hardware or in sim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time torque-current telemetry for drive, flywheel, hood, intake, feeder, prestage, and transport motors.
  * Telemetry is refreshed periodically and made available alongside existing motor status data.
  * Expanded monitoring coverage to include both primary and follower motors where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->