### PR TITLE
Log motor temperatures in Celsius instead of Kelvin

### DIFF
--- a/src/main/java/frc/robot/subsystems/flywheel/io/FlywheelIO.java
+++ b/src/main/java/frc/robot/subsystems/flywheel/io/FlywheelIO.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.flywheel.io;
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
@@ -9,7 +8,6 @@ import static edu.wpi.first.units.Units.Volts;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
-import edu.wpi.first.units.measure.Temperature;
 import edu.wpi.first.units.measure.Voltage;
 import org.littletonrobotics.junction.AutoLog;
 
@@ -38,7 +36,8 @@ public interface FlywheelIO {
     public Voltage leaderAppliedVolts = Volts.of(0);
     public Current leaderSupplyCurrentAmps = Amps.of(0);
     public Current leaderStatorCurrentAmps = Amps.of(0);
-    public Temperature leaderTemp = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double leaderTemp = 0.0;
 
     public Angle leaderAngle = Rotations.of(0);
 
@@ -47,28 +46,32 @@ public interface FlywheelIO {
     public Voltage follower1AppliedVolts = Volts.of(0);
     public Current follower1SupplyCurrentAmps = Amps.of(0);
     public Current follower1StatorCurrentAmps = Amps.of(0);
-    public Temperature follower1Temp = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double follower1Temp = 0.0;
 
     // Follower 2 motor
     public AngularVelocity follower2Velocity = RotationsPerSecond.of(0);
     public Voltage follower2AppliedVolts = Volts.of(0);
     public Current follower2SupplyCurrentAmps = Amps.of(0);
     public Current follower2StatorCurrentAmps = Amps.of(0);
-    public Temperature follower2Temp = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double follower2Temp = 0.0;
 
     // Follower 3 motor
     public AngularVelocity follower3Velocity = RotationsPerSecond.of(0);
     public Voltage follower3AppliedVolts = Volts.of(0);
     public Current follower3SupplyCurrentAmps = Amps.of(0);
     public Current follower3StatorCurrentAmps = Amps.of(0);
-    public Temperature follower3Temp = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double follower3Temp = 0.0;
 
     // Follower 4 motor
     public AngularVelocity follower4Velocity = RotationsPerSecond.of(0);
     public Voltage follower4AppliedVolts = Volts.of(0);
     public Current follower4SupplyCurrentAmps = Amps.of(0);
     public Current follower4StatorCurrentAmps = Amps.of(0);
-    public Temperature follower4Temp = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double follower4Temp = 0.0;
   }
 
   /** Read sensor data from the flywheel motor. */

--- a/src/main/java/frc/robot/subsystems/flywheel/io/FlywheelIOPhoenix6.java
+++ b/src/main/java/frc/robot/subsystems/flywheel/io/FlywheelIOPhoenix6.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.flywheel.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
@@ -289,7 +290,7 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
     inputs.leaderAppliedVolts = leaderMotorVoltage.getValue();
     inputs.leaderSupplyCurrentAmps = leaderSupplyCurrent.getValue();
     inputs.leaderStatorCurrentAmps = leaderStatorCurrent.getValue();
-    inputs.leaderTemp = leaderTemp.getValue();
+    inputs.leaderTemp = leaderTemp.getValue().in(Celsius);
     inputs.leaderAngle = leaderPos.getValue();
 
     // Follower 1 motor — read from cache
@@ -297,28 +298,28 @@ public class FlywheelIOPhoenix6 implements FlywheelIO {
     inputs.follower1AppliedVolts = follower1MotorVoltage.getValue();
     inputs.follower1SupplyCurrentAmps = follower1SupplyCurrent.getValue();
     inputs.follower1StatorCurrentAmps = follower1StatorCurrent.getValue();
-    inputs.follower1Temp = follower1Temp.getValue();
+    inputs.follower1Temp = follower1Temp.getValue().in(Celsius);
 
     // Follower 2 motor — read from cache
     inputs.follower2Velocity = follower2Velocity.getValue();
     inputs.follower2AppliedVolts = follower2MotorVoltage.getValue();
     inputs.follower2SupplyCurrentAmps = follower2SupplyCurrent.getValue();
     inputs.follower2StatorCurrentAmps = follower2StatorCurrent.getValue();
-    inputs.follower2Temp = follower2Temp.getValue();
+    inputs.follower2Temp = follower2Temp.getValue().in(Celsius);
 
     // Follower 3 motor — read from cache
     inputs.follower3Velocity = follower3Velocity.getValue();
     inputs.follower3AppliedVolts = follower3MotorVoltage.getValue();
     inputs.follower3SupplyCurrentAmps = follower3SupplyCurrent.getValue();
     inputs.follower3StatorCurrentAmps = follower3StatorCurrent.getValue();
-    inputs.follower3Temp = follower3Temp.getValue();
+    inputs.follower3Temp = follower3Temp.getValue().in(Celsius);
 
     // Follower 4 motor — read from cache
     inputs.follower4Velocity = follower4Velocity.getValue();
     inputs.follower4AppliedVolts = follower4MotorVoltage.getValue();
     inputs.follower4SupplyCurrentAmps = follower4SupplyCurrent.getValue();
     inputs.follower4StatorCurrentAmps = follower4StatorCurrent.getValue();
-    inputs.follower4Temp = follower4Temp.getValue();
+    inputs.follower4Temp = follower4Temp.getValue().in(Celsius);
 
     // Combined flywheel velocity (use leader velocity as representative)
     inputs.flywheelVelocity = inputs.leaderVelocity;

--- a/src/main/java/frc/robot/subsystems/flywheel/io/FlywheelIOSim.java
+++ b/src/main/java/frc/robot/subsystems/flywheel/io/FlywheelIOSim.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.flywheel.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
@@ -142,7 +143,7 @@ public class FlywheelIOSim implements FlywheelIO {
     inputs.leaderAppliedVolts = leader.getMotorVoltage().getValue();
     inputs.leaderSupplyCurrentAmps = leader.getSupplyCurrent().getValue();
     inputs.leaderStatorCurrentAmps = leader.getStatorCurrent().getValue();
-    inputs.leaderTemp = leader.getDeviceTemp().getValue();
+    inputs.leaderTemp = leader.getDeviceTemp().getValue().in(Celsius);
     inputs.leaderAngle = leader.getPosition().getValue();
 
     // Follower 1 motor
@@ -150,28 +151,28 @@ public class FlywheelIOSim implements FlywheelIO {
     inputs.follower1AppliedVolts = follower1.getMotorVoltage().getValue();
     inputs.follower1SupplyCurrentAmps = follower1.getSupplyCurrent().getValue();
     inputs.follower1StatorCurrentAmps = follower1.getStatorCurrent().getValue();
-    inputs.follower1Temp = follower1.getDeviceTemp().getValue();
+    inputs.follower1Temp = follower1.getDeviceTemp().getValue().in(Celsius);
 
     // Follower 2 motor
     inputs.follower2Velocity = follower2.getVelocity().getValue();
     inputs.follower2AppliedVolts = follower2.getMotorVoltage().getValue();
     inputs.follower2SupplyCurrentAmps = follower2.getSupplyCurrent().getValue();
     inputs.follower2StatorCurrentAmps = follower2.getStatorCurrent().getValue();
-    inputs.follower2Temp = follower2.getDeviceTemp().getValue();
+    inputs.follower2Temp = follower2.getDeviceTemp().getValue().in(Celsius);
 
     // Follower 3 motor
     inputs.follower3Velocity = follower3.getVelocity().getValue();
     inputs.follower3AppliedVolts = follower3.getMotorVoltage().getValue();
     inputs.follower3SupplyCurrentAmps = follower3.getSupplyCurrent().getValue();
     inputs.follower3StatorCurrentAmps = follower3.getStatorCurrent().getValue();
-    inputs.follower3Temp = follower3.getDeviceTemp().getValue();
+    inputs.follower3Temp = follower3.getDeviceTemp().getValue().in(Celsius);
 
     // Follower 4 motor
     inputs.follower4Velocity = follower4.getVelocity().getValue();
     inputs.follower4AppliedVolts = follower4.getMotorVoltage().getValue();
     inputs.follower4SupplyCurrentAmps = follower4.getSupplyCurrent().getValue();
     inputs.follower4StatorCurrentAmps = follower4.getStatorCurrent().getValue();
-    inputs.follower4Temp = follower4.getDeviceTemp().getValue();
+    inputs.follower4Temp = follower4.getDeviceTemp().getValue().in(Celsius);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/hood/io/HoodIO.java
+++ b/src/main/java/frc/robot/subsystems/hood/io/HoodIO.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.hood.io;
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.DegreesPerSecond;
 import static edu.wpi.first.units.Units.Volts;
@@ -9,7 +8,6 @@ import static edu.wpi.first.units.Units.Volts;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
-import edu.wpi.first.units.measure.Temperature;
 import edu.wpi.first.units.measure.Voltage;
 import org.littletonrobotics.junction.AutoLog;
 
@@ -20,7 +18,9 @@ public interface HoodIO {
     public Voltage hoodVoltage = Volts.of(0);
     public Current hoodSupplyCurrent = Amps.of(0);
     public Current hoodStatorCurrent = Amps.of(0);
-    public Temperature hoodTemperature = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double hoodTemperature = 0.0;
+
     public AngularVelocity hoodVelocity = DegreesPerSecond.of(0);
     public Angle hoodPosition = Degrees.of(0);
     public Angle hoodClosedLoopReference = Degrees.of(0);

--- a/src/main/java/frc/robot/subsystems/hood/io/HoodIOReal.java
+++ b/src/main/java/frc/robot/subsystems/hood/io/HoodIOReal.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.hood.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.Seconds;
@@ -169,7 +170,7 @@ public class HoodIOReal implements HoodIO {
     inputs.hoodVoltage = motorVoltage.getValue();
     inputs.hoodStatorCurrent = statorCurrent.getValue();
     inputs.hoodSupplyCurrent = supplyCurrent.getValue();
-    inputs.hoodTemperature = deviceTemp.getValue();
+    inputs.hoodTemperature = deviceTemp.getValue().in(Celsius);
     // closedLoopReference and closedLoopError are raw doubles in mechanism rotations.
     // Convert to degrees so all hood angles are in degrees throughout the codebase.
     inputs.hoodClosedLoopReference = Degrees.of(closedLoopReference.getValueAsDouble() * 360.0);

--- a/src/main/java/frc/robot/subsystems/intakePivot/io/IntakePivotIO.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/io/IntakePivotIO.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.intakePivot.io;
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
@@ -9,7 +8,6 @@ import static edu.wpi.first.units.Units.Volts;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
-import edu.wpi.first.units.measure.Temperature;
 import edu.wpi.first.units.measure.Voltage;
 import org.littletonrobotics.junction.AutoLog;
 
@@ -26,7 +24,9 @@ public interface IntakePivotIO {
     public Voltage intakePivotVoltage = Volts.of(0);
     public Current intakePivotSupplyCurrent = Amps.of(0);
     public Current intakePivotStatorCurrent = Amps.of(0);
-    public Temperature intakePivotTemperature = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double intakePivotTemperature = 0.0;
+
     public AngularVelocity intakePivotVelocity = RotationsPerSecond.of(0);
     public Angle intakePivotPosition = Rotations.of(0);
     public double intakePivotClosedLoopReference;

--- a/src/main/java/frc/robot/subsystems/intakePivot/io/IntakePivotIOReal.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/io/IntakePivotIOReal.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.intakePivot.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.Second;
 
@@ -183,7 +184,7 @@ public class IntakePivotIOReal implements IntakePivotIO {
     inputs.intakePivotVoltage = motorVoltage.getValue();
     inputs.intakePivotStatorCurrent = statorCurrent.getValue();
     inputs.intakePivotSupplyCurrent = supplyCurrent.getValue();
-    inputs.intakePivotTemperature = deviceTemp.getValue();
+    inputs.intakePivotTemperature = deviceTemp.getValue().in(Celsius);
     inputs.intakePivotClosedLoopReference = closedLoopReference.getValueAsDouble();
     inputs.intakePivotClosedLoopError = closedLoopError.getValueAsDouble();
   }

--- a/src/main/java/frc/robot/subsystems/intakePivot/io/IntakePivotIOSim.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/io/IntakePivotIOSim.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.intakePivot.io;
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
@@ -92,7 +91,7 @@ public class IntakePivotIOSim implements IntakePivotIO {
     inputs.intakePivotVoltage = Volts.of(appliedVolts);
     inputs.intakePivotStatorCurrent = Amps.of(Math.abs(pivotSim.getCurrentDrawAmps()));
     inputs.intakePivotSupplyCurrent = Amps.of(Math.abs(pivotSim.getCurrentDrawAmps()));
-    inputs.intakePivotTemperature = Celsius.of(25.0); // sim doesn't model temperature
+    inputs.intakePivotTemperature = 25.0; // sim doesn't model temperature
 
     // Closed-loop reference and error in mechanism rotations
     if (controlMode == ControlMode.POSITION) {

--- a/src/main/java/frc/robot/subsystems/intakeRoller/io/intakeRollerIO.java
+++ b/src/main/java/frc/robot/subsystems/intakeRoller/io/intakeRollerIO.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.intakeRoller.io;
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
@@ -9,7 +8,6 @@ import static edu.wpi.first.units.Units.Volts;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
-import edu.wpi.first.units.measure.Temperature;
 import edu.wpi.first.units.measure.Voltage;
 import org.littletonrobotics.junction.AutoLog;
 
@@ -20,7 +18,9 @@ public interface intakeRollerIO {
     public Voltage intakeRollerVoltage = Volts.of(0);
     public Current intakeRollerSupplyCurrent = Amps.of(0);
     public Current intakeRollerStatorCurrent = Amps.of(0);
-    public Temperature intakeRollerTemperature = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double intakeRollerTemperature = 0.0;
+
     public AngularVelocity intakeRollerVelocity = RotationsPerSecond.of(0);
     public AngularVelocity rollerClosedLoopReference = RotationsPerSecond.of(0);
     public AngularVelocity rollerClosedLoopError = RotationsPerSecond.of(0);
@@ -28,7 +28,9 @@ public interface intakeRollerIO {
     public Voltage intakeRollerFollowerVoltage = Volts.of(0);
     public Current intakeRollerFollowerSupplyCurrent = Amps.of(0);
     public Current intakeRollerFollowerStatorCurrent = Amps.of(0);
-    public Temperature intakeRollerFollowerTemperature = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double intakeRollerFollowerTemperature = 0.0;
+
     public AngularVelocity intakeRollerFollowerVelocity = RotationsPerSecond.of(0);
     public AngularVelocity rollerFollowerClosedLoopReference = RotationsPerSecond.of(0);
     public AngularVelocity rollerFollowerClosedLoopError = RotationsPerSecond.of(0);

--- a/src/main/java/frc/robot/subsystems/intakeRoller/io/intakeRollerIOReal.java
+++ b/src/main/java/frc/robot/subsystems/intakeRoller/io/intakeRollerIOReal.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.intakeRoller.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Second;
 
@@ -156,7 +157,7 @@ public class intakeRollerIOReal implements intakeRollerIO {
     inputs.intakeRollerStatorCurrent = statorCurrent.getValue();
     inputs.intakeRollerSupplyCurrent = supplyCurrent.getValue();
     inputs.intakeRollerVoltage = motorVoltage.getValue();
-    inputs.intakeRollerTemperature = deviceTemp.getValue();
+    inputs.intakeRollerTemperature = deviceTemp.getValue().in(Celsius);
     inputs.rollerClosedLoopReference =
         RotationsPerSecond.of(closedLoopReference.getValueAsDouble());
     inputs.rollerClosedLoopError = RotationsPerSecond.of(closedLoopError.getValueAsDouble());
@@ -165,7 +166,7 @@ public class intakeRollerIOReal implements intakeRollerIO {
     inputs.intakeRollerFollowerStatorCurrent = FollowerstatorCurrent.getValue();
     inputs.intakeRollerFollowerSupplyCurrent = FollowersupplyCurrent.getValue();
     inputs.intakeRollerFollowerVoltage = FollowermotorVoltage.getValue();
-    inputs.intakeRollerFollowerTemperature = FollowerdeviceTemp.getValue();
+    inputs.intakeRollerFollowerTemperature = FollowerdeviceTemp.getValue().in(Celsius);
     inputs.rollerFollowerClosedLoopReference =
         RotationsPerSecond.of(FollowerclosedLoopReference.getValueAsDouble());
     inputs.rollerFollowerClosedLoopError =

--- a/src/main/java/frc/robot/subsystems/intakeRoller/io/intakeRollerIOSim.java
+++ b/src/main/java/frc/robot/subsystems/intakeRoller/io/intakeRollerIOSim.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.intakeRoller.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
@@ -120,7 +121,7 @@ public class intakeRollerIOSim implements intakeRollerIO {
     inputs.intakeRollerVoltage = intakeRollerLeader.getMotorVoltage().getValue();
     inputs.intakeRollerStatorCurrent = intakeRollerLeader.getStatorCurrent().getValue();
     inputs.intakeRollerSupplyCurrent = intakeRollerLeader.getSupplyCurrent().getValue();
-    inputs.intakeRollerTemperature = intakeRollerLeader.getDeviceTemp().getValue();
+    inputs.intakeRollerTemperature = intakeRollerLeader.getDeviceTemp().getValue().in(Celsius);
     inputs.rollerClosedLoopReference =
         RotationsPerSecond.of(intakeRollerLeader.getClosedLoopReference().getValueAsDouble());
     inputs.rollerClosedLoopError =
@@ -132,7 +133,8 @@ public class intakeRollerIOSim implements intakeRollerIO {
     inputs.intakeRollerFollowerVoltage = intakeRollerFollower.getMotorVoltage().getValue();
     inputs.intakeRollerFollowerStatorCurrent = intakeRollerFollower.getStatorCurrent().getValue();
     inputs.intakeRollerFollowerSupplyCurrent = intakeRollerFollower.getSupplyCurrent().getValue();
-    inputs.intakeRollerFollowerTemperature = intakeRollerFollower.getDeviceTemp().getValue();
+    inputs.intakeRollerFollowerTemperature =
+        intakeRollerFollower.getDeviceTemp().getValue().in(Celsius);
     inputs.rollerFollowerClosedLoopReference =
         RotationsPerSecond.of(intakeRollerFollower.getClosedLoopReference().getValueAsDouble());
     inputs.rollerFollowerClosedLoopError =

--- a/src/main/java/frc/robot/subsystems/lowerFeeder/io/LowerFeederIO.java
+++ b/src/main/java/frc/robot/subsystems/lowerFeeder/io/LowerFeederIO.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.lowerFeeder.io;
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
@@ -9,7 +8,6 @@ import static edu.wpi.first.units.Units.Volts;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
-import edu.wpi.first.units.measure.Temperature;
 import edu.wpi.first.units.measure.Voltage;
 import org.littletonrobotics.junction.AutoLog;
 
@@ -21,7 +19,9 @@ public interface LowerFeederIO {
     public Current lowerFeederStatorAmps = Amps.of(0);
     public Current lowerFeederSupplyAmps = Amps.of(0);
     public AngularVelocity lowerFeederMotorVelocity = RotationsPerSecond.of(0);
-    public Temperature lowerFeederMotorTemperature = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double lowerFeederMotorTemperature = 0.0;
+
     public AngularVelocity lowerFeederClosedLoopReference = RotationsPerSecond.of(0);
     public AngularVelocity lowerFeederClosedLoopError = RotationsPerSecond.of(0);
     public Angle lowerFeederPos = Rotations.of(0);

--- a/src/main/java/frc/robot/subsystems/lowerFeeder/io/LowerFeederIOReal.java
+++ b/src/main/java/frc/robot/subsystems/lowerFeeder/io/LowerFeederIOReal.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.lowerFeeder.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Second;
 
@@ -117,7 +118,7 @@ public class LowerFeederIOReal implements LowerFeederIO {
     inputs.lowerFeederStatorAmps = statorCurrent.getValue();
     inputs.lowerFeederSupplyAmps = supplyCurrent.getValue();
     inputs.lowerFeederVoltage = motorVoltage.getValue();
-    inputs.lowerFeederMotorTemperature = deviceTemp.getValue();
+    inputs.lowerFeederMotorTemperature = deviceTemp.getValue().in(Celsius);
     inputs.lowerFeederClosedLoopReference =
         RotationsPerSecond.of(closedLoopReference.getValueAsDouble());
     inputs.lowerFeederClosedLoopError = RotationsPerSecond.of(closedLoopError.getValueAsDouble());

--- a/src/main/java/frc/robot/subsystems/lowerFeeder/io/LowerFeederIOSim.java
+++ b/src/main/java/frc/robot/subsystems/lowerFeeder/io/LowerFeederIOSim.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.lowerFeeder.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
@@ -119,7 +120,7 @@ public class LowerFeederIOSim implements LowerFeederIO {
     inputs.lowerFeederVoltage = lowerFeederMotor.getMotorVoltage().getValue();
     inputs.lowerFeederStatorAmps = lowerFeederMotor.getStatorCurrent().getValue();
     inputs.lowerFeederSupplyAmps = lowerFeederMotor.getSupplyCurrent().getValue();
-    inputs.lowerFeederMotorTemperature = lowerFeederMotor.getDeviceTemp().getValue();
+    inputs.lowerFeederMotorTemperature = lowerFeederMotor.getDeviceTemp().getValue().in(Celsius);
     inputs.lowerFeederClosedLoopReference =
         RotationsPerSecond.of(lowerFeederMotor.getClosedLoopReference().getValueAsDouble());
     inputs.lowerFeederClosedLoopError =

--- a/src/main/java/frc/robot/subsystems/prestage/io/PrestageIO.java
+++ b/src/main/java/frc/robot/subsystems/prestage/io/PrestageIO.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.prestage.io;
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
@@ -9,7 +8,6 @@ import static edu.wpi.first.units.Units.Volts;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
-import edu.wpi.first.units.measure.Temperature;
 import edu.wpi.first.units.measure.Voltage;
 import org.littletonrobotics.junction.AutoLog;
 
@@ -27,8 +25,10 @@ public interface PrestageIO {
     public AngularVelocity prestageLeftVelocity = RotationsPerSecond.of(0);
     public AngularVelocity prestageRightVelocity = RotationsPerSecond.of(0);
 
-    public Temperature prestageLeftTemperature = Celsius.of(0);
-    public Temperature prestageRightTemperature = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double prestageLeftTemperature = 0.0;
+    /** Degrees Celsius. */
+    public double prestageRightTemperature = 0.0;
 
     public AngularVelocity prestageLeftClosedLoopReference = RotationsPerSecond.of(0);
     public AngularVelocity prestageRightClosedLoopReference = RotationsPerSecond.of(0);

--- a/src/main/java/frc/robot/subsystems/prestage/io/PrestageIOReal.java
+++ b/src/main/java/frc/robot/subsystems/prestage/io/PrestageIOReal.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.prestage.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Second;
 
@@ -166,7 +167,7 @@ public class PrestageIOReal implements PrestageIO {
     inputs.prestageLeftStatorAmps = leftStatorCurrent.getValue();
     inputs.prestageLeftSupplyAmps = leftSupplyCurrent.getValue();
     inputs.prestageLeftVoltage = leftMotorVoltage.getValue();
-    inputs.prestageLeftTemperature = leftDeviceTemp.getValue();
+    inputs.prestageLeftTemperature = leftDeviceTemp.getValue().in(Celsius);
     inputs.prestageLeftClosedLoopReference =
         RotationsPerSecond.of(leftClosedLoopReference.getValueAsDouble());
     inputs.prestageLeftClosedLoopError =
@@ -178,7 +179,7 @@ public class PrestageIOReal implements PrestageIO {
     inputs.prestageRightStatorAmps = rightStatorCurrent.getValue();
     inputs.prestageRightSupplyAmps = rightSupplyCurrent.getValue();
     inputs.prestageRightVoltage = rightMotorVoltage.getValue();
-    inputs.prestageRightTemperature = rightDeviceTemp.getValue();
+    inputs.prestageRightTemperature = rightDeviceTemp.getValue().in(Celsius);
     inputs.prestageRightClosedLoopReference =
         RotationsPerSecond.of(rightClosedLoopReference.getValueAsDouble());
     inputs.prestageRightClosedLoopError =

--- a/src/main/java/frc/robot/subsystems/prestage/io/PrestageIOSim.java
+++ b/src/main/java/frc/robot/subsystems/prestage/io/PrestageIOSim.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.prestage.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
@@ -142,7 +143,7 @@ public class PrestageIOSim implements PrestageIO {
     inputs.prestageLeftVoltage = prestageLeft.getMotorVoltage().getValue();
     inputs.prestageLeftStatorAmps = prestageLeft.getStatorCurrent().getValue();
     inputs.prestageLeftSupplyAmps = prestageLeft.getSupplyCurrent().getValue();
-    inputs.prestageLeftTemperature = prestageLeft.getDeviceTemp().getValue();
+    inputs.prestageLeftTemperature = prestageLeft.getDeviceTemp().getValue().in(Celsius);
     inputs.prestageLeftClosedLoopReference =
         RotationsPerSecond.of(prestageLeft.getClosedLoopReference().getValueAsDouble());
     inputs.prestageLeftClosedLoopError =
@@ -154,7 +155,7 @@ public class PrestageIOSim implements PrestageIO {
     inputs.prestageRightVoltage = prestageRight.getMotorVoltage().getValue();
     inputs.prestageRightStatorAmps = prestageRight.getStatorCurrent().getValue();
     inputs.prestageRightSupplyAmps = prestageRight.getSupplyCurrent().getValue();
-    inputs.prestageRightTemperature = prestageRight.getDeviceTemp().getValue();
+    inputs.prestageRightTemperature = prestageRight.getDeviceTemp().getValue().in(Celsius);
     inputs.prestageRightClosedLoopReference =
         RotationsPerSecond.of(prestageRight.getClosedLoopReference().getValueAsDouble());
     inputs.prestageRightClosedLoopError =

--- a/src/main/java/frc/robot/subsystems/transport/io/TransportIO.java
+++ b/src/main/java/frc/robot/subsystems/transport/io/TransportIO.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.transport.io;
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
@@ -9,7 +8,6 @@ import static edu.wpi.first.units.Units.Volts;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
-import edu.wpi.first.units.measure.Temperature;
 import edu.wpi.first.units.measure.Voltage;
 import org.littletonrobotics.junction.AutoLog;
 
@@ -21,7 +19,9 @@ public interface TransportIO {
     public Current TransportStatorAmps = Amps.of(0);
     public Current TransportSupplyAmps = Amps.of(0);
     public AngularVelocity TransportMotorVelocity = RotationsPerSecond.of(0);
-    public Temperature TransportMotorTemperature = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double TransportMotorTemperature = 0.0;
+
     public AngularVelocity transportClosedLoopReference = RotationsPerSecond.of(0);
     public AngularVelocity transportClosedLoopError = RotationsPerSecond.of(0);
     public Angle transportPos = Rotations.of(0);

--- a/src/main/java/frc/robot/subsystems/transport/io/TransportIOReal.java
+++ b/src/main/java/frc/robot/subsystems/transport/io/TransportIOReal.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.transport.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Second;
 
@@ -117,7 +118,7 @@ public class TransportIOReal implements TransportIO {
     inputs.TransportStatorAmps = statorCurrent.getValue();
     inputs.TransportSupplyAmps = supplyCurrent.getValue();
     inputs.TransportVoltage = motorVoltage.getValue();
-    inputs.TransportMotorTemperature = deviceTemp.getValue();
+    inputs.TransportMotorTemperature = deviceTemp.getValue().in(Celsius);
     inputs.transportClosedLoopReference =
         RotationsPerSecond.of(closedLoopReference.getValueAsDouble());
     inputs.transportClosedLoopError = RotationsPerSecond.of(closedLoopError.getValueAsDouble());

--- a/src/main/java/frc/robot/subsystems/transport/io/TransportIOSim.java
+++ b/src/main/java/frc/robot/subsystems/transport/io/TransportIOSim.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.transport.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
@@ -108,7 +109,7 @@ public class TransportIOSim implements TransportIO {
     inputs.TransportVoltage = transportMotor.getMotorVoltage().getValue();
     inputs.TransportStatorAmps = transportMotor.getStatorCurrent().getValue();
     inputs.TransportSupplyAmps = transportMotor.getSupplyCurrent().getValue();
-    inputs.TransportMotorTemperature = transportMotor.getDeviceTemp().getValue();
+    inputs.TransportMotorTemperature = transportMotor.getDeviceTemp().getValue().in(Celsius);
     inputs.transportClosedLoopReference =
         RotationsPerSecond.of(transportMotor.getClosedLoopReference().getValueAsDouble());
     inputs.transportClosedLoopError =

--- a/src/main/java/frc/robot/subsystems/upperFeeder/io/UpperFeederIO.java
+++ b/src/main/java/frc/robot/subsystems/upperFeeder/io/UpperFeederIO.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.upperFeeder.io;
 
 import static edu.wpi.first.units.Units.Amps;
-import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
@@ -9,7 +8,6 @@ import static edu.wpi.first.units.Units.Volts;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
-import edu.wpi.first.units.measure.Temperature;
 import edu.wpi.first.units.measure.Voltage;
 import org.littletonrobotics.junction.AutoLog;
 
@@ -21,7 +19,9 @@ public interface UpperFeederIO {
     public Current upperFeederStatorAmps = Amps.of(0);
     public Current upperFeederSupplyAmps = Amps.of(0);
     public AngularVelocity upperFeederMotorVelocity = RotationsPerSecond.of(0);
-    public Temperature upperFeederMotorTemperature = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double upperFeederMotorTemperature = 0.0;
+
     public AngularVelocity upperFeederClosedLoopReference = RotationsPerSecond.of(0);
     public AngularVelocity upperFeederClosedLoopError = RotationsPerSecond.of(0);
     public Angle upperFeederPos = Rotations.of(0);

--- a/src/main/java/frc/robot/subsystems/upperFeeder/io/UpperFeederIOReal.java
+++ b/src/main/java/frc/robot/subsystems/upperFeeder/io/UpperFeederIOReal.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.upperFeeder.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Second;
 
@@ -117,7 +118,7 @@ public class UpperFeederIOReal implements UpperFeederIO {
     inputs.upperFeederStatorAmps = statorCurrent.getValue();
     inputs.upperFeederSupplyAmps = supplyCurrent.getValue();
     inputs.upperFeederVoltage = motorVoltage.getValue();
-    inputs.upperFeederMotorTemperature = deviceTemp.getValue();
+    inputs.upperFeederMotorTemperature = deviceTemp.getValue().in(Celsius);
     inputs.upperFeederClosedLoopReference =
         RotationsPerSecond.of(closedLoopReference.getValueAsDouble());
     inputs.upperFeederClosedLoopError = RotationsPerSecond.of(closedLoopError.getValueAsDouble());

--- a/src/main/java/frc/robot/subsystems/upperFeeder/io/UpperFeederIOSim.java
+++ b/src/main/java/frc/robot/subsystems/upperFeeder/io/UpperFeederIOSim.java
@@ -1,5 +1,6 @@
 package frc.robot.subsystems.upperFeeder.io;
 
+import static edu.wpi.first.units.Units.Celsius;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
@@ -116,7 +117,7 @@ public class UpperFeederIOSim implements UpperFeederIO {
     inputs.upperFeederVoltage = feederMotor.getMotorVoltage().getValue();
     inputs.upperFeederStatorAmps = feederMotor.getStatorCurrent().getValue();
     inputs.upperFeederSupplyAmps = feederMotor.getSupplyCurrent().getValue();
-    inputs.upperFeederMotorTemperature = feederMotor.getDeviceTemp().getValue();
+    inputs.upperFeederMotorTemperature = feederMotor.getDeviceTemp().getValue().in(Celsius);
     inputs.upperFeederClosedLoopReference =
         RotationsPerSecond.of(feederMotor.getClosedLoopReference().getValueAsDouble());
     inputs.upperFeederClosedLoopError =


### PR DESCRIPTION
## The problem

Motor temperatures show as ~300 in AdvantageScope. They aren't wrong — they're in Kelvin.

`LogTable.put(String, Measure)` records the value in its **base unit** and tags the entry with that unit's name:

```java
put(key, new LogValue(value.baseUnitMagnitude(), null, value.baseUnit().name()));
```

The base unit of `Temperature` is Kelvin, so every `Temperature` field in an `@AutoLog` inputs class lands in the log as Kelvin. AdvantageKit's own javadoc on that method points at the fix:

> This overload always records the value in its base unit. Use the double overload with a unit string to record values with alternative units.

`@AutoLog` selects the overload from the field's declared type, so reaching the double overload means the field has to be a `double`.

## The change

The 14 `Temperature` fields across the eight mechanism IO layers become doubles holding Celsius:

```diff
-    public Temperature hoodTemperature = Celsius.of(0);
+    /** Degrees Celsius. */
+    public double hoodTemperature = 0.0;
```
```diff
-    inputs.hoodTemperature = deviceTemp.getValue();
+    inputs.hoodTemperature = deviceTemp.getValue().in(Celsius);
```

**Field names are unchanged, so log keys are unchanged.** Existing AdvantageScope layouts keep working — the numbers just become the ones people expect. Verified against the generated `HoodIOInputsAutoLogged`: the key is still `"HoodTemperature"`.

## One tradeoff worth knowing

A plain `double` carries no unit metadata in the log. Previously the entry was tagged `"Kelvin"` by the `Measure` overload; now it is untagged. `@AutoLog` can't emit the unit-string overload, so with an unsuffixed field name there is no way to keep the tag. Each field is commented with its unit so the code is self-documenting even though the log isn't.

## Why only Temperature

`AngularVelocity` and `Angle` inputs also log in base units (rad/s, radians), but **those fields feed control decisions**:

- `Flywheel.isSpunUp()` reads `inputs.leaderVelocity.in(RPM)`
- `IntakePivot.periodic()` reads `inputs.intakePivotPosition.in(Rotations)`
- `Hood.getPosition()` returns `inputs.hoodPosition`

A unit slip there changes how the robot behaves, not just how a graph looks. `Temperature` is read **nowhere outside the IO layer** — verified — so this change cannot affect robot behavior at all. Angles and velocities are handled separately.

`Voltage` and `Current` are left alone deliberately: their base units already *are* volts and amps, so they were never wrong.

## Per the AdvantageKit integrity rule

Both the real and sim implementations were updated for every changed field. `IntakePivotIOSim`'s hardcoded `Celsius.of(25.0)` became a plain `25.0`.

## Verification

- `./gradlew compileJava` ✅
- `./gradlew spotlessCheck` ✅
- `./gradlew build` ✅
- `./gradlew simulateJava` ✅ starts and runs clean, no exceptions
- Generated `*AutoLogged` classes inspected — log keys identical to `main`

Not tested on hardware. The change is telemetry-only and touches no control path, but a bench check of one motor's reported temperature would confirm it end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)